### PR TITLE
docs(readme): drop the codecov graph token from badge URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ go get github.com/a-novel-kit/jwt
 ```
 
 ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/a-novel-kit/jwt/main.yaml)
-[![codecov](https://codecov.io/gh/a-novel-kit/jwt/graph/badge.svg?token=OoJuHDI2lf)](https://codecov.io/gh/a-novel-kit/jwt)
+[![codecov](https://codecov.io/gh/a-novel-kit/jwt/graph/badge.svg)](https://codecov.io/gh/a-novel-kit/jwt)
 [![Go Report Card](https://goreportcard.com/badge/github.com/a-novel-kit/jwt)](https://goreportcard.com/report/github.com/a-novel-kit/jwt)
 
 ![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/a-novel-kit/jwt)
 ![GitHub repo file or directory count](https://img.shields.io/github/directory-file-count/a-novel-kit/jwt)
 ![GitHub code size in bytes](https://img.shields.io/github/languages/code-size/a-novel-kit/jwt)
 
-![Coverage graph](https://codecov.io/gh/a-novel-kit/jwt/graphs/sunburst.svg?token=OoJuHDI2lf)
+![Coverage graph](https://codecov.io/gh/a-novel-kit/jwt/graphs/sunburst.svg)


### PR DESCRIPTION
Public-repo Codecov badges render without a token, so the graph token in the badge + sunburst URLs is unnecessary. Stripping it for cleaner, tokenless badges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)