### PR TITLE
fix(docs): target esnext to fix the VitePress build on master

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -3,6 +3,15 @@ import { tabsMarkdownPlugin } from "vitepress-plugin-tabs";
 
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
+  // Vite 8's default browser target makes esbuild try to downlevel
+  // destructuring in the VitePress client bundle, which esbuild 0.28 can't do
+  // ("Transforming destructuring ... is not supported yet"). Docs ship to
+  // modern browsers, so target esnext and skip the downleveling entirely.
+  vite: {
+    build: {
+      target: "esnext",
+    },
+  },
   title: "JWT",
   titleTemplate: "A-Novel Kit",
   themeConfig: {


### PR DESCRIPTION
The `docs` job has been failing on master (3 consecutive runs):

```
[vite:esbuild-transpile] Transform failed with 2 errors:
assets/app.!~{006}~.js:24:10: ERROR: Transforming destructuring to the configured target environment ("chrome87", "edge88", "es2020", "firefox78", "safari14" + 2 overrides) is not supported yet
```

Vite 8's default browser target makes esbuild try to downlevel destructuring in the VitePress client bundle, and esbuild 0.28 can't do that transform — so `vitepress build` dies. (Surfaced after the recent `vite`/`esbuild` bumps.)

## Fix
Set `vite.build.target` to `esnext` in the VitePress config. Docs ship to modern browsers, so there's no reason to downlevel; this skips the transform esbuild chokes on.

## Verified
`pnpm docs:build` reproduces the failure on master and succeeds with this change (`build complete in 3.37s`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)