### PR TITLE
docs: refocus comments on rationale and refine project docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,9 +67,6 @@ pnpm lint
 a-novel test --type=go -y
 ```
 
-Run `pnpm generate:go` only when a generated Go input changes. Keep generated artifacts in the same commit as the
-source change that required them.
-
 ## Questions?
 
 Open an issue in this repository when the question is specific to `jwt`. Use the platform onboarding guide for general

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,7 @@ Thank you for improving the security of `A-Novel`. We appreciate your efforts an
 responsible disclosure and will make every effort to acknowledge your
 contributions.
 
-Report security bugs by emailing the lead maintainer at geoffroy.vincent@agoradesecrivains.com.
+Report security bugs by emailing the lead maintainer at geoffroy.vincent@agorastoryverse.com.
 
 The lead maintainer will acknowledge your email within 48 hours, and will send a
 more detailed response within 48 hours indicating the next steps in handling

--- a/crit.go
+++ b/crit.go
@@ -6,8 +6,14 @@ import (
 	"fmt"
 )
 
+// ErrMissingCritHeader is returned when the "crit" list names a header parameter that is absent
+// from the header being checked.
 var ErrMissingCritHeader = errors.New("missing crit header value")
 
+// CheckCrit verifies that every parameter named in crit is present in data, the JSON object of
+// extra header parameters. The JOSE "crit" list marks parameters a recipient is required to
+// understand, so a listed name with no matching value makes the token invalid. An empty crit list
+// passes unconditionally.
 func CheckCrit(data json.RawMessage, crit []string) error {
 	if len(crit) == 0 {
 		return nil

--- a/jwa/algs.go
+++ b/jwa/algs.go
@@ -1,147 +1,104 @@
+// Package jwa defines the JOSE data types shared across the jwt toolkit: the
+// algorithm, key, header, and claim structures of the JSON Web Signature,
+// Encryption, Key, and Token specifications (RFC 7515-7519, RFC 8037).
+//
+// The package holds only the wire types and their registered constant values.
+// It carries no cryptographic logic; the serialization and signing packages
+// build on these types.
 package jwa
 
+// Alg identifies a cryptographic algorithm named in a JOSE header's "alg"
+// parameter, covering both JWS signing and JWE key management.
 type Alg string
 
 func (alg Alg) String() string {
 	return string(alg)
 }
 
+// None is the "alg" value of an unsecured token, one carrying no signature.
 const None Alg = "none"
 
+// Empty reports whether no signing algorithm is applied: the value is unset or
+// explicitly None.
 func (alg Alg) Empty() bool {
 	return alg == "" || alg == None
 }
 
-// JWS algorithms.
+// JWS signing algorithms registered by RFC 7518.
 // https://datatracker.ietf.org/doc/html/rfc7518#section-3.1
 const (
-	// HS256 signing algorithm.
-	//
-	// HMAC using SHA-256.
+	// HS256 signs with HMAC using SHA-256.
 	HS256 Alg = "HS256"
-	// HS384 signing algorithm.
-	//
-	// HMAC using SHA-384.
+	// HS384 signs with HMAC using SHA-384.
 	HS384 Alg = "HS384"
-	// HS512 signing algorithm.
-	//
-	// HMAC using SHA-512.
+	// HS512 signs with HMAC using SHA-512.
 	HS512 Alg = "HS512"
 
-	// RS256 signing algorithm.
-	//
-	// RSASSA-PKCS1-v1_5 using SHA-256.
+	// RS256 signs with RSASSA-PKCS1-v1_5 using SHA-256.
 	RS256 Alg = "RS256"
-	// RS384 signing algorithm.
-	//
-	// RSASSA-PKCS1-v1_5 using SHA-384.
+	// RS384 signs with RSASSA-PKCS1-v1_5 using SHA-384.
 	RS384 Alg = "RS384"
-	// RS512 signing algorithm.
-	//
-	// RSASSA-PKCS1-v1_5 using SHA-512.
+	// RS512 signs with RSASSA-PKCS1-v1_5 using SHA-512.
 	RS512 Alg = "RS512"
 
-	// ES256 signing algorithm.
-	//
-	// ECDSA using P-256 and SHA-256.
+	// ES256 signs with ECDSA using P-256 and SHA-256.
 	ES256 Alg = "ES256"
-	// ES384 signing algorithm.
-	//
-	// ECDSA using P-384 and SHA-384.
+	// ES384 signs with ECDSA using P-384 and SHA-384.
 	ES384 Alg = "ES384"
-	// ES512 signing algorithm.
-	//
-	// ECDSA using P-521 and SHA-512.
+	// ES512 signs with ECDSA using P-521 and SHA-512.
 	ES512 Alg = "ES512"
 
-	// PS256 signing algorithm.
-	//
-	// RSASSA-PSS using SHA-256 and MGF1 with SHA-256.
+	// PS256 signs with RSASSA-PSS using SHA-256 and MGF1 with SHA-256.
 	PS256 Alg = "PS256"
-	// PS384 signing algorithm.
-	//
-	// RSASSA-PSS using SHA-384 and MGF1 with SHA-384.
+	// PS384 signs with RSASSA-PSS using SHA-384 and MGF1 with SHA-384.
 	PS384 Alg = "PS384"
-	// PS512 signing algorithm.
-	//
-	// RSASSA-PSS using SHA-512 and MGF1 with SHA-512.
+	// PS512 signs with RSASSA-PSS using SHA-512 and MGF1 with SHA-512.
 	PS512 Alg = "PS512"
 
-	// EdDSA signing algorithm.
+	// EdDSA signs with the Edwards-curve Digital Signature Algorithm.
 	EdDSA Alg = "EdDSA"
 )
 
-// JWE key management algorithms.
+// JWE key management algorithms registered by RFC 7518.
 // https://datatracker.ietf.org/doc/html/rfc7518#section-4.1
 const (
-	// RSAOAEP key management algorithm.
-	//
-	// RSAES OAEP using default parameters.
+	// RSAOAEP wraps the content encryption key with RSAES OAEP using default parameters.
 	RSAOAEP Alg = "RSA-OAEP"
-	// RSAOAEP256 key management algorithm.
-	//
-	// RSAES OAEP using SHA-256 and MGF1 with SHA-256.
+	// RSAOAEP256 wraps the content encryption key with RSAES OAEP using SHA-256 and MGF1 with SHA-256.
 	RSAOAEP256 Alg = "RSA-OAEP-256"
 
-	// A128KW key management algorithm.
-	//
-	// AES Key Wrap with default initial value using 128-bit key.
+	// A128KW wraps the content encryption key with AES Key Wrap using a 128-bit key.
 	A128KW Alg = "A128KW"
-	// A192KW key management algorithm.
-	//
-	// AES Key Wrap with default initial value using 192-bit key.
+	// A192KW wraps the content encryption key with AES Key Wrap using a 192-bit key.
 	A192KW Alg = "A192KW"
-	// A256KW key management algorithm.
-	//
-	// AES Key Wrap with default initial value using 256-bit key.
+	// A256KW wraps the content encryption key with AES Key Wrap using a 256-bit key.
 	A256KW Alg = "A256KW"
 
-	// DIR key management algorithm.
-	//
-	// Direct use of a shared symmetric key as the CEK.
+	// DIR uses a shared symmetric key directly as the content encryption key.
 	DIR Alg = "dir"
 
-	// ECDHES key management algorithm.
-	//
-	// Elliptic Curve Diffie-Hellman Ephemeral Static key agreement using Concat KDF.
+	// ECDHES derives the content encryption key with Elliptic Curve Diffie-Hellman
+	// Ephemeral Static key agreement and Concat KDF.
 	ECDHES Alg = "ECDH-ES"
 
-	// ECDHESA128KW key management algorithm.
-	//
-	// ECDH-ES using Concat KDF and CEK wrapped with A128KW.
+	// ECDHESA128KW derives a key with ECDH-ES and Concat KDF, then wraps the CEK with A128KW.
 	ECDHESA128KW Alg = "ECDH-ES+A128KW"
-	// ECDHESA192KW key management algorithm.
-	//
-	// ECDH-ES using Concat KDF and CEK wrapped with A192KW.
+	// ECDHESA192KW derives a key with ECDH-ES and Concat KDF, then wraps the CEK with A192KW.
 	ECDHESA192KW Alg = "ECDH-ES+A192KW"
-	// ECDHESA256KW key management algorithm.
-	//
-	// ECDH-ES using Concat KDF and CEK wrapped with A256KW.
+	// ECDHESA256KW derives a key with ECDH-ES and Concat KDF, then wraps the CEK with A256KW.
 	ECDHESA256KW Alg = "ECDH-ES+A256KW"
 
-	// A128GCMKW key management algorithm.
-	//
-	// Key wrapping with AES GCM using 128-bit key.
+	// A128GCMKW wraps the content encryption key with AES GCM using a 128-bit key.
 	A128GCMKW Alg = "A128GCMKW"
-	// A192GCMKW key management algorithm.
-	//
-	// Key wrapping with AES GCM using 192-bit key.
+	// A192GCMKW wraps the content encryption key with AES GCM using a 192-bit key.
 	A192GCMKW Alg = "A192GCMKW"
-	// A256GCMKW key management algorithm.
-	//
-	// Key wrapping with AES GCM using 256-bit key.
+	// A256GCMKW wraps the content encryption key with AES GCM using a 256-bit key.
 	A256GCMKW Alg = "A256GCMKW"
 
-	// PBES2HS256A128KW key management algorithm.
-	//
-	// PBES2 with HMAC SHA-256 and A128KW key wrapping.
+	// PBES2HS256A128KW derives a key from a password with PBES2 (HMAC SHA-256) and wraps the CEK with A128KW.
 	PBES2HS256A128KW Alg = "PBES2-HS256+A128KW"
-	// PBES2HS384A192KW key management algorithm.
-	//
-	// PBES2 with HMAC SHA-384 and A192KW key wrapping.
+	// PBES2HS384A192KW derives a key from a password with PBES2 (HMAC SHA-384) and wraps the CEK with A192KW.
 	PBES2HS384A192KW Alg = "PBES2-HS384+A192KW"
-	// PBES2HS512A256KW key management algorithm.
-	//
-	// PBES2 with HMAC SHA-512 and A256KW key wrapping.
+	// PBES2HS512A256KW derives a key from a password with PBES2 (HMAC SHA-512) and wraps the CEK with A256KW.
 	PBES2HS512A256KW Alg = "PBES2-HS512+A256KW"
 )

--- a/jwa/curves.go
+++ b/jwa/curves.go
@@ -1,6 +1,10 @@
 package jwa
 
+// Curve names for Octet Key Pair (OKP) keys.
+// https://datatracker.ietf.org/doc/html/rfc8037#section-3
 const (
-	CrvX25519  = "X25519"
+	// CrvX25519 is the curve used for ECDH-ES key agreement.
+	CrvX25519 = "X25519"
+	// CrvEd25519 is the curve used for EdDSA signatures.
 	CrvEd25519 = "Ed25519"
 )

--- a/jwa/enc.go
+++ b/jwa/enc.go
@@ -1,36 +1,28 @@
 package jwa
 
+// Enc identifies the content encryption algorithm named in a JWE "enc" header.
+// Each value is an AEAD algorithm applied to the plaintext to produce the
+// ciphertext and authentication tag.
 type Enc string
 
 func (enc Enc) String() string {
 	return string(enc)
 }
 
+// Content encryption algorithms registered by RFC 7518.
 // https://datatracker.ietf.org/doc/html/rfc7518#section-5.1
 const (
-	// A128CBC encryption algorithm.
-	//
-	// AES_128_CBC_HMAC_SHA_256 authenticated encryption algorithm.
+	// A128CBC encrypts with AES-128-CBC and authenticates with HMAC SHA-256.
 	A128CBC Enc = "A128CBC-HS256"
-	// A192CBC encryption algorithm.
-	//
-	// AES_192_CBC_HMAC_SHA_384 authenticated encryption algorithm.
+	// A192CBC encrypts with AES-192-CBC and authenticates with HMAC SHA-384.
 	A192CBC Enc = "A192CBC-HS384"
-	// A256CBC encryption algorithm.
-	//
-	// AES_256_CBC_HMAC_SHA_512 authenticated encryption algorithm.
+	// A256CBC encrypts with AES-256-CBC and authenticates with HMAC SHA-512.
 	A256CBC Enc = "A256CBC-HS512"
 
-	// A128GCM encryption algorithm.
-	//
-	// AES_128_GCM authenticated encryption algorithm.
+	// A128GCM encrypts and authenticates with AES-128-GCM.
 	A128GCM Enc = "A128GCM"
-	// A192GCM encryption algorithm.
-	//
-	// AES_192_GCM authenticated encryption algorithm.
+	// A192GCM encrypts and authenticates with AES-192-GCM.
 	A192GCM Enc = "A192GCM"
-	// A256GCM encryption algorithm.
-	//
-	// AES_256_GCM authenticated encryption algorithm.
+	// A256GCM encrypts and authenticates with AES-256-GCM.
 	A256GCM Enc = "A256GCM"
 )

--- a/jwa/errors.go
+++ b/jwa/errors.go
@@ -2,4 +2,6 @@ package jwa
 
 import "errors"
 
+// ErrUnsupportedKeyType is returned when an operation receives a key whose
+// type it does not support.
 var ErrUnsupportedKeyType = errors.New("unsupported key type")

--- a/jwa/internal/json_partial.go
+++ b/jwa/internal/json_partial.go
@@ -1,3 +1,6 @@
+// Package internal provides JSON helpers for payloads that combine a fixed set of
+// typed fields with arbitrary caller-defined ones, letting a JWT carry both
+// registered claims and custom extensions in a single object.
 package internal
 
 import (
@@ -5,6 +8,9 @@ import (
 	"fmt"
 )
 
+// MarshalPartial encodes common and custom into one JSON object, with custom's
+// members overriding any that collide with common. A nil or "null" custom yields
+// the encoding of common alone.
 func MarshalPartial[T any](common T, custom json.RawMessage) ([]byte, error) {
 	if custom == nil || string(custom) == "null" {
 		return json.Marshal(common)
@@ -35,6 +41,9 @@ func MarshalPartial[T any](common T, custom json.RawMessage) ([]byte, error) {
 	return mergedSerialized, nil
 }
 
+// UnmarshalPartial decodes the typed fields of src into a value of type T and
+// returns src unchanged alongside it, so the caller can later decode its own
+// custom fields from the same bytes.
 func UnmarshalPartial[T any](src []byte) (T, json.RawMessage, error) {
 	var common T
 

--- a/jwa/jwh.go
+++ b/jwa/jwh.go
@@ -6,7 +6,9 @@ import (
 	"github.com/a-novel-kit/jwt/jwa/internal"
 )
 
-// Typ represents the "typ" field of a JWT header.
+// Typ is the "typ" (type) header parameter. It declares the media type of the
+// complete token, letting an application tell a JWT apart from other objects
+// that might appear in the same position. Optional.
 //
 // https://datatracker.ietf.org/doc/html/rfc7519#section-5.1
 type Typ string
@@ -16,31 +18,28 @@ func (typ Typ) String() string {
 }
 
 const (
-	TypJWT     Typ = "JWT"
-	TypJOSE    Typ = "JOSE"
+	// TypJWT marks the object as a JWT.
+	TypJWT Typ = "JWT"
+	// TypJOSE marks the object as a JWS or JWE in compact serialization.
+	TypJOSE Typ = "JOSE"
+	// TypJOSEJWT marks a JOSE object carrying a JWT.
 	TypJOSEJWT Typ = "JOSE+JWT"
 )
 
-// CTY represents the "cty" field of a JWT header.
+// CTY is the "cty" (content type) header parameter. It conveys structural
+// information about the token; on a nested JWT it must be set to CtyJWT.
 //
 // https://datatracker.ietf.org/doc/html/rfc7519#section-5.2
 type CTY string
 
+// CtyJWT marks the secured content as itself being a JWT, as required on a
+// nested JWT.
 const CtyJWT CTY = "JWT"
 
-// JWHCommon is a JOSE header.
+// JWHCommon holds the JOSE header parameters shared by JWS and JWE tokens. The
+// members that apply depend on whether the token is signed or encrypted.
 //
 // https://datatracker.ietf.org/doc/html/rfc7519#section-5
-//
-// # For a JWT object, the members of the JSON object represented by the
-// JOSE Header describe the cryptographic operations applied to the JWT
-// and optionally, additional properties of the JWT. Depending upon
-// whether the JWT is a JWS or JWE, the corresponding rules for the JOSE
-// Header values apply.
-//
-// This specification further specifies the use of the following Header
-// Parameters in both the cases where the JWT is a JWS and where it is a
-// JWE.
 type JWHCommon struct {
 	JWHEmbeddedKey
 
@@ -50,357 +49,101 @@ type JWHCommon struct {
 
 	J509
 
-	// JWT header.
-	//
+	// Typ declares the media type of the complete token. See the Typ constants.
 	// https://datatracker.ietf.org/doc/html/rfc7519#section-5.1
-	//
-	// The "typ" (type) Header Parameter defined by [JWS] and [JWE] is used
-	// by JWT applications to declare the media type [IANA.MediaTypes] of
-	// this complete JWT. This is intended for use by the JWT application
-	// when values that are not JWTs could also be present in an application
-	// data structure that can contain a JWT object; the application can use
-	// this value to disambiguate among the different kinds of objects that
-	// might be present. It will typically not be used by applications when
-	// it is already known that the object is a JWT. This parameter is
-	// ignored by JWT implementations; any processing of this parameter is
-	// performed by the JWT application. If present, it is RECOMMENDED that
-	// its value be "JWT" to indicate that this object is a JWT. While
-	// media type names are not case-sensitive, it is RECOMMENDED that "JWT"
-	// always be spelled using uppercase characters for compatibility with
-	// legacy implementations. Use of this Header Parameter is OPTIONAL.
-	//
-	// https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.9
-	//
-	// The "typ" (type) Header Parameter is used by JWS applications to
-	// declare the media type [IANA.MediaTypes] of this complete JWS. This
-	// is intended for use by the application when more than one kind of
-	// object could be present in an application data structure that can
-	// contain a JWS; the application can use this value to disambiguate
-	// among the different kinds of objects that might be present. It will
-	// typically not be used by applications when the kind of object is
-	// already known. This parameter is ignored by JWS implementations; any
-	// processing of this parameter is performed by the JWS application.
-	// Use of this Header Parameter is OPTIONAL.
-	//
-	// Per RFC 2045 [RFC2045], all media type values, subtype values, and
-	// parameter names are case insensitive. However, parameter values are
-	// case sensitive unless otherwise specified for the specific parameter.
-	// To keep messages compact in common situations, it is RECOMMENDED that
-	// producers omit an "application/" prefix of a media type value in a
-	// "typ" Header Parameter when no other '/' appears in the media type
-	// value. A recipient using the media type value MUST treat it as if
-	// "application/" were prepended to any "typ" value not containing a
-	// '/'. For instance, a "typ" value of "example" SHOULD be used to
-	// represent the "application/example" media type, whereas the media
-	// type "application/example;part="1/2"" cannot be shortened to
-	// "example;part="1/2"".
-	//
-	// The "typ" value "JOSE" can be used by applications to indicate that
-	// this object is a JWS or JWE using the JWS Compact Serialization or
-	// the JWE Compact Serialization. The "typ" value "JOSE+JSON" can be
-	// used by applications to indicate that this object is a JWS or JWE
-	// using the JWS JSON Serialization or the JWE JSON Serialization.
-	// Other type values can also be used by applications.
 	Typ Typ `json:"typ,omitempty"`
-	// CTY header.
-	//
+	// CTY conveys structural information about the token. On a nested JWT it is
+	// CtyJWT.
 	// https://datatracker.ietf.org/doc/html/rfc7519#section-5.2
-	//
-	// The "cty" (content type) Header Parameter defined by [JWS] and [JWE]
-	// is used by this specification to convey structural information about
-	// the JWT.
-	//
-	// In the normal case in which nested signing or encryption operations
-	// are not employed, the use of this Header Parameter is NOT
-	// RECOMMENDED. In the case that nested signing or encryption is
-	// employed, this Header Parameter MUST be present; in this case, the
-	// value MUST be "JWT", to indicate that a Nested JWT is carried in this
-	// JWT. While media type names are not case-sensitive, it is
-	// RECOMMENDED that "JWT" always be spelled using uppercase characters
-	// for compatibility with legacy implementations. See Appendix A.2 for
-	// an example of a Nested JWT.
-	//
-	// https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.10
-	//
-	// The "cty" (content type) Header Parameter is used by JWS applications
-	// to declare the media type [IANA.MediaTypes] of the secured content
-	// (the payload). This is intended for use by the application when more
-	// than one kind of object could be present in the JWS J509; the
-	// application can use this value to disambiguate among the different
-	// kinds of objects that might be present. It will typically not be
-	// used by applications when the kind of object is already known. This
-	// parameter is ignored by JWS implementations; any processing of this
-	// parameter is performed by the JWS application. Use of this Header
-	// Parameter is OPTIONAL.
-	//
-	// Per RFC 2045 [RFC2045], all media type values, subtype values, and
-	// parameter names are case insensitive. However, parameter values are
-	// case sensitive unless otherwise specified for the specific parameter.
-	//
-	// To keep messages compact in common situations, it is RECOMMENDED that
-	// producers omit an "application/" prefix of a media type value in a
-	// "cty" Header Parameter when no other '/' appears in the media type
-	// value. A recipient using the media type value MUST treat it as if
-	// "application/" were prepended to any "cty" value not containing a
-	// '/'. For instance, a "cty" value of "example" SHOULD be used to
-	// represent the "application/example" media type, whereas the media
-	// type "application/example;part="1/2"" cannot be shortened to
-	// "example;part="1/2"".
-	//
-	// Values:
-	// - CtyJWT
 	CTY CTY `json:"cty,omitempty"`
 
-	// Alg header.
-	//
+	// Alg identifies the algorithm securing the token. It must be present and
+	// understood by the recipient.
 	// https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.1
-	//
-	// The "alg" (algorithm) Header Parameter identifies the cryptographic
-	// algorithm used to secure the JWS. The JWS Signature value is not
-	// valid if the "alg" value does not represent a supported algorithm or
-	// if there is not a key for use with that algorithm associated with the
-	// party that digitally signed or MACed the content. "alg" values
-	// should either be registered in the IANA "JSON Web Signature and
-	// Encryption Algorithms" registry established by [JWA] or be a value
-	// that contains a Collision-Resistant Name. The "alg" value is a case-
-	// sensitive ASCII string containing a StringOrURI value. This Header
-	// Parameter MUST be present and MUST be understood and processed by
-	// implementations.
-	//
-	// A list of defined "alg" values for this use can be found in the IANA
-	// "JSON Web Signature and Encryption Algorithms" registry established
-	// by [JWA]; the initial contents of this registry are the values
-	// defined in Section 3.1 of [JWA].
 	Alg Alg `json:"alg,omitempty"`
-	// Enc header.
-	//
+	// Enc identifies the content encryption algorithm of a JWE. Required on
+	// encrypted tokens.
 	// https://datatracker.ietf.org/doc/html/rfc7516#section-4.1.2
-	// The "enc" (encryption algorithm) Header Parameter identifies the
-	// content encryption algorithm used to perform authenticated encryption
-	// on the plaintext to produce the ciphertext and the Authentication
-	// Tag. This algorithm MUST be an AEAD algorithm with a specified key
-	// length. The encrypted content is not usable if the "enc" value does
-	// not represent a supported algorithm. "enc" values should either be
-	// registered in the IANA "JSON Web Signature and Encryption Algorithms"
-	// registry established by [JWA] or be a value that contains a
-	// Collision-Resistant Name. The "enc" value is a case-sensitive ASCII
-	// string containing a StringOrURI value. This Header Parameter MUST be
-	// present and MUST be understood and processed by implementations.
 	Enc Enc `json:"enc,omitempty"`
-	// Zip header.
-	//
+	// Zip names the compression applied to the plaintext before encryption, if
+	// any. When set it must live in the protected header.
 	// https://datatracker.ietf.org/doc/html/rfc7516#section-4.1.3
-	//
-	// The "zip" (compression algorithm) applied to the plaintext before
-	// encryption, if any. The "zip" value defined by this specification
-	// is:
-	//
-	// o "DEF" - Compression with the DEFLATE [RFC1951] algorithm
-	//
-	// Other values MAY be used. Compression algorithm values can be
-	// registered in the IANA "JSON Web Encryption Compression Algorithms"
-	// registry established by [JWA]. The "zip" value is a case-sensitive
-	// string. If no "zip" parameter is present, no compression is applied
-	// to the plaintext before encryption. When used, this Header Parameter
-	// MUST be integrity protected; therefore, it MUST occur only within the
-	// JWE Protected Header. Use of this Header Parameter is OPTIONAL.
-	// This Header Parameter MUST be understood and processed by
-	// implementations.
 	Zip Zip `json:"zip,omitempty"`
 
-	// Crit (Critical) Header Parameter.
-	//
+	// Crit lists header parameters, introduced by extensions, that the recipient
+	// must understand; an unrecognized entry invalidates the token. It must not
+	// be empty when present, nor name parameters defined by the base
+	// specifications.
 	// https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.11
-	//
-	// The "crit" (critical) Header Parameter indicates that extensions to
-	// this specification and/or [JWA] are being used that MUST be
-	// understood and processed. Its value is an array listing the Header
-	// Parameter names present in the JOSE Header that use those extensions.
-	// If any of the listed extension Header Parameters are not understood
-	// and supported by the recipient, then the JWS is invalid. Producers
-	// MUST NOT include Header Parameter names defined by this specification
-	// or [JWA] for use with JWS, duplicate names, or names that do not
-	// occur as Header Parameter names within the JOSE Header in the "crit"
-	// list. Producers MUST NOT use the empty list "[]" as the "crit"
-	// value. Recipients MAY consider the JWS to be invalid if the critical
-	// list contains any Header Parameter names defined by this
-	// specification or [JWA] for use with JWS or if any other constraints
-	// on its use are violated. When used, this Header Parameter MUST be
-	// integrity protected; therefore, it MUST occur only within the JWS
-	// Protected Header. Use of this Header Parameter is OPTIONAL. This
-	// Header Parameter MUST be understood and processed by implementations.
-	//
-	// An example use, along with a hypothetical "exp" (expiration time)
-	// field is:
-	//
-	// {"alg":"ES256",
-	// "crit":["exp"],
-	// "exp":1363284000
-	// }
 	Crit []string `json:"crit,omitempty"`
 
+	// The following claims may be replicated from an encrypted token's payload
+	// into its header, so a recipient can act on them without first decrypting
+	// the body. When present, their values must match those in the payload.
 	// https://datatracker.ietf.org/doc/html/rfc7519#section-5.3
-	//
-	// In some applications using encrypted JWTs, it is useful to have an
-	// unencrypted representation of some claims. This might be used, for
-	// instance, in application processing rules to determine whether and
-	// how to process the JWT before it is decrypted.
-	//
-	// This specification allows claims present in the JWT Claims Set to be
-	// replicated as Header Parameters in a JWT that is a JWE, as needed by
-	// the application. If such replicated claims are present, the
-	// application receiving them SHOULD verify that their values are
-	// identical, unless the application defines other specific processing
-	// rules for these claims. It is the responsibility of the application
-	// to ensure that only claims that are safe to be transmitted in an
-	// unencrypted manner are replicated as Header Parameter values in the
-	// JWT.
-	//
-	// Section 10.4.1 of this specification registers the "iss" (producer),
-	// "sub" (subject), and "aud" (audience) Header Parameter names for the
-	// purpose of providing unencrypted replicas of these claims in
-	// encrypted JWTs for applications that need them. Other specifications
-	// MAY similarly register other names that are registered Claim Names as
-	// Header Parameter names, as needed.
 
-	// Iss is the producer of the token.
-	//
-	// This parameter is replicated from the body, to allow processing of encrypted body, where this information is
-	// not available.
-	//
-	// https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.1
-	//
-	// The "iss" (producer) claim identifies the principal that issued the
-	// JWT. The processing of this claim is generally application specific.
-	// The "iss" value is a case-sensitive string containing a StringOrURI
-	// value. Use of this claim is OPTIONAL.
+	// Iss mirrors the payload's issuer claim.
 	Iss string `json:"iss,omitempty"`
-	// Sub is the subject of the token.
-	//
-	// This parameter is replicated from the body, to allow processing of encrypted body, where this information is
-	// not available.
-	//
-	// https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.2
-	//
-	// The "sub" (subject) claim identifies the principal that is the
-	// subject of the JWT. The claims in a JWT are normally statements
-	// about the subject. The subject value MUST either be scoped to be
-	// locally unique in the context of the producer or be globally unique.
-	// The processing of this claim is generally application specific. The
-	// "sub" value is a case-sensitive string containing a StringOrURI
-	// value. Use of this claim is OPTIONAL.
+	// Sub mirrors the payload's subject claim.
 	Sub string `json:"sub,omitempty"`
-	// Aud is the audience of the token.
-	//
-	// This parameter is replicated from the body, to allow processing of encrypted body, where this information is
-	// not available.
-	//
-	// https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3
-	//
-	// The "aud" (audience) claim identifies the recipients that the JWT is
-	// intended for. Each principal intended to process the JWT MUST
-	// identify itself with a value in the audience claim. If the principal
-	// processing the claim does not identify itself with a value in the
-	// "aud" claim when this claim is present, then the JWT MUST be
-	// rejected. In the general case, the "aud" value is an array of case-
-	// sensitive strings, each containing a StringOrURI value. In the
-	// special case when the JWT has one audience, the "aud" value MAY be a
-	// single case-sensitive string containing a StringOrURI value. The
-	// interpretation of audience values is generally application specific.
-	// Use of this claim is OPTIONAL.
+	// Aud mirrors the payload's audience claim.
 	Aud string `json:"aud,omitempty"`
 }
 
+// JWHEmbeddedKey carries the header parameters that reference or embed the key
+// used to secure the token.
 type JWHEmbeddedKey struct {
-	// JKU (JWK Set URL) Header Parameter.
-	//
+	// JKU is a URL to a JWK Set holding the public key that verifies the token.
+	// The fetch must be integrity-protected.
 	// https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.2
-	//
-	// The "jku" (JWK Set URL) Header Parameter is a URI [RFC3986] that
-	// refers to a resource for a set of JSON-encoded public keys, one of
-	// which corresponds to the key used to digitally sign the JWS. The
-	// keys MUST be encoded as a JWK Set [JWKCommon]. The protocol used to
-	// acquire the resource MUST provide integrity protection; an HTTP GET
-	// request to retrieve the JWK Set MUST use Transport Layer Security
-	// (TLS) [RFC2818] [RFC5246]; and the identity of the server MUST be
-	// validated, as per Section 6 of RFC 6125 [RFC6125]. Also, see
-	// Section 8 on TLS requirements. Use of this Header Parameter is
-	// OPTIONAL.
 	JKU string `json:"jku,omitempty"`
-	// JWK (JSON Web CEK) Header Parameter.
-	//
+	// JWK embeds the public key that verifies the token.
 	// https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.3
-	//
-	// The "jwk" (JSON Web CEK) Header Parameter is the public key that
-	// corresponds to the key used to digitally sign the JWS. This key is
-	// represented as a JSON Web CEK [JWKCommon]. Use of this Header Parameter is
-	// OPTIONAL.
 	JWK *JWK `json:"jwk,omitempty"`
-	// KID (Key ID) Header Parameter.
-	//
+	// KID hints which key secured the token, letting an originator signal a key
+	// change. When keys are matched by identifier, it is compared against a
+	// JWK's KID.
 	// https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.4
-	//
-	// The "kid" (key ID) Header Parameter is a hint indicating which key
-	// was used to secure the JWS. This parameter allows originators to
-	// explicitly signal a change of key to recipients. The structure of
-	// the "kid" value is unspecified. Its value MUST be a case-sensitive
-	// string. Use of this Header Parameter is OPTIONAL.
-	//
-	// When used with a JWK, the "kid" value is used to match a JWK "kid"
-	// parameter value.
 	KID string `json:"kid,omitempty"`
 }
 
+// JWHKeyAgreement carries the header parameters of ECDH key agreement
+// algorithms such as ECDH-ES.
 type JWHKeyAgreement struct {
-	// EPK is the Ephemeral Public Key Header Parameter.
-	//
+	// EPK is the ephemeral public key the originator created for key agreement.
+	// It holds public key parameters only.
 	// https://datatracker.ietf.org/doc/html/rfc7518#section-4.6.1.1
-	//
-	// The "epk" (ephemeral public key) value created by the originator for
-	// the use in key agreement algorithms. This key is represented as a
-	// JSON Web Key [JWKCommon] public key value. It MUST contain only public key
-	// parameters and SHOULD contain only the minimum JWKCommon parameters
-	// necessary to represent the key; other JWKCommon parameters included can be
-	// checked for consistency and honored, or they can be ignored. This
-	// Header Parameter MUST be present and MUST be understood and processed
-	// by implementations when these algorithms are used.
 	EPK *JWK `json:"epk,omitempty"`
-	// APU is the Agreement PartyUInfo Header Parameter.
-	//
+	// APU is agreement PartyUInfo: base64url-encoded information about the
+	// producer, consumed by key agreement.
 	// https://datatracker.ietf.org/doc/html/rfc7518#section-4.6.1.2
-	//
-	// The "apu" (agreement PartyUInfo) value for key agreement algorithms
-	// using it (such as "ECDH-ES"), represented as a base64url-encoded
-	// string. When used, the PartyUInfo value contains information about
-	// the producer. Use of this Header Parameter is OPTIONAL. This Header
-	// Parameter MUST be understood and processed by implementations when
-	// these algorithms are used.
 	APU string `json:"apu,omitempty"`
-	// APV is the Agreement PartyVInfo Header Parameter.
-	//
+	// APV is agreement PartyVInfo: base64url-encoded information about the
+	// recipient, consumed by key agreement.
 	// https://datatracker.ietf.org/doc/html/rfc7518#section-4.6.1.3
-	//
-	// The "apv" (agreement PartyVInfo) value for key agreement algorithms
-	// using it (such as "ECDH-ES"), represented as a base64url encoded
-	// string. When used, the PartyVInfo value contains information about
-	// the recipient. Use of this Header Parameter is OPTIONAL. This
-	// Header Parameter MUST be understood and processed by implementations
-	// when these algorithms are used.
 	APV string `json:"apv,omitempty"`
 }
 
+// JWHPBES2 carries the salt and iteration count of the PBES2 password-based
+// key-derivation algorithms.
 type JWHPBES2 struct {
-	// P2S is the salt input of the PBES2 algorithm.
+	// P2S is the salt input to PBES2.
 	P2S string `json:"p2s,omitempty"`
-	// P2C is the iteration count of the PBES2 algorithm.
+	// P2C is the PBES2 iteration count.
 	P2C int `json:"p2c,omitempty"`
 }
 
+// JWHAESGCMKW carries the initialization vector and authentication tag of the
+// AES GCM key-wrapping algorithms.
 type JWHAESGCMKW struct {
-	IV  string `json:"iv,omitempty"`
+	// IV is the initialization vector used to wrap the key.
+	IV string `json:"iv,omitempty"`
+	// Tag is the authentication tag produced when wrapping the key.
 	Tag string `json:"tag,omitempty"`
 }
 
+// JWH is a full JOSE header: the common parameters plus an application-specific
+// payload. Marshaling merges the two into one JSON object.
 type JWH struct {
 	JWHCommon
 

--- a/jwa/jwk.go
+++ b/jwa/jwk.go
@@ -8,165 +8,39 @@ import (
 	"github.com/a-novel-kit/jwt/jwa/internal"
 )
 
-// JWKCommon represents a key in standard JSOM web key format.
+// JWKCommon holds the parameters common to every JSON Web Key, independent of
+// key type. Type-specific parameters (the actual key material) live alongside
+// them in the payload; see JWK.
 //
 // https://datatracker.ietf.org/doc/html/rfc7517#section-4
-//
-// A JWKCommon is a JSON object that represents a cryptographic key. The
-// members of the object represent properties of the key, including its
-// value. This JSON object MAY contain whitespace and/or line breaks
-// before or after any JSON values or structural characters, in
-// accordance with Section 2 of RFC 7159 [RFC7159]. This document
-// defines the key parameters that are not algorithm specific and, thus,
-// common to many keys.
-//
-// In addition to the common parameters, each JWKCommon will have members that
-// are key type specific. These members represent the parameters of the
-// key. Section 6 of the JSON Web Algorithms (JWA) [JWA] specification
-// defines multiple kinds of cryptographic keys and their associated
-// members.
-//
-// The member names within a JWKCommon MUST be unique; JWKCommon parsers MUST either
-// reject JWKs with duplicate member names or use a JSON parser that
-// returns only the lexically last duplicate member name, as specified
-// in Section 15.12 (The JSON Object) of ECMAScript 5.1 [ECMAScript].
-//
-// Additional members can be present in the JWKCommon; if not understood by
-// implementations encountering them, they MUST be ignored. Member
-// names used for representing key parameters for different keys types
-// need not be distinct. Any new member name should either be
-// registered in the IANA "JSON Web CEK Parameters" registry established
-// by Section 8.1 or be a value that contains a Collision-Resistant
-// Name.
 type JWKCommon struct {
 	J509
 
-	// KTY represents the "kty" (key type) parameter in a JSON web key.
-	//
+	// KTY is the key type, the cryptographic algorithm family of the key. It is
+	// the only required member of a JWK.
 	// https://datatracker.ietf.org/doc/html/rfc7518#section-6.1
-	//
-	// The "kty" (key type) parameter identifies the cryptographic algorithm
-	// family used with the key, such as "RSA" or "EC". "kty" values should
-	// either be registered in the IANA "JSON Web CEK Types" registry
-	// established by [JWA] or be a value that contains a Collision-
-	// Resistant Name. The "kty" value is a case-sensitive string. This
-	// member MUST be present in a JWKCommon.
-	//
-	// A list of defined "kty" values can be found in the IANA "JSON Web CEK
-	// Types" registry established by [JWA]; the initial contents of this
-	// registry are the values defined in Section 6.1 of [JWA].
-	//
-	// The key type definitions include specification of the members to be
-	// used for those key types. Members used with specific "kty" values
-	// can be found in the IANA "JSON Web CEK Parameters" registry
-	// established by Section 8.1.
 	KTY KTY `json:"kty"`
-	// Use represents the "use" parameter in a JSON web key.
-	//
+	// Use marks the key as intended for signing or for encryption. It is
+	// mutually informative with KeyOps and should stay consistent with it.
 	// https://datatracker.ietf.org/doc/html/rfc7517#section-4.2
-	//
-	// The "use" (public key use) parameter identifies the intended use of
-	// the public key. The "use" parameter is employed to indicate whether
-	// a public key is used for encrypting data or verifying the signature
-	// on data.
-	//
-	// Values defined by this specification are:
-	//
-	// o "sig" (signature)
-	// o "enc" (encryption)
-	//
-	// Other values MAY be used. The "use" value is a case-sensitive
-	// string. Use of the "use" member is OPTIONAL, unless the application
-	// requires its presence.
-	//
-	// When a key is used to wrap another key and a public key use
-	// designation for the first key is desired, the "enc" (encryption) key
-	// use value is used, since key wrapping is a kind of encryption. The
-	// "enc" value is also to be used for public keys used for key agreement
-	// operations.
-	//
-	// Additional "use" (public key use) values can be registered in the
-	// IANA "JSON Web CEK Use" registry established by Section 8.2.
-	// Registering any extension values used is highly recommended when this
-	// specification is used in open environments, in which multiple
-	// organizations need to have a common understanding of any extensions
-	// used. However, unregistered extension values can be used in closed
-	// environments, in which the producing and consuming organization will
-	// always be the same.
 	Use Use `json:"use,omitempty"`
-	// KeyOps represents the "key_ops" parameter in a JSON web key.
-	//
+	// KeyOps lists the operations the key may perform. It offers finer control
+	// than Use; the two should not disagree when both are set.
 	// https://datatracker.ietf.org/doc/html/rfc7517#section-4.3
-	//
-	// The "key_ops" (key operations) parameter identifies the operation(s)
-	// for which the key is intended to be used. The "key_ops" parameter is
-	// intended for use cases in which public, private, or symmetric keys
-	// may be present.
-	//
-	// Its value is an array of key operation values. Values defined by
-	// this specification are:
-	//
-	// o "sign" (compute digital signature or MAC)
-	// o "verify" (verify digital signature or MAC)
-	// o "encrypt" (encrypt content)
-	// o "decrypt" (decrypt content and validate decryption, if applicable)
-	// o "wrapKey" (encrypt key)
-	// o "unwrapKey" (decrypt key and validate decryption, if applicable)
-	// o "deriveKey" (derive key)
-	// o "deriveBits" (derive bits not to be used as a key)
-	//
-	// (Note that the "key_ops" values intentionally match the "KeyUsage"
-	// values defined in the Web Cryptography API
-	// [W3C.CR-WebCryptoAPI-20141211] specification.)
-	//
-	// Other values MAY be used. The key operation values are case-
-	// sensitive strings. Duplicate key operation values MUST NOT be
-	// present in the array. Use of the "key_ops" member is OPTIONAL,
-	// unless the application requires its presence.
-	//
-	// Multiple unrelated key operations SHOULD NOT be specified for a key
-	// because of the potential vulnerabilities associated with using the
-	// same key with multiple algorithms. Thus, the combinations "sign"
-	// with "verify", "encrypt" with "decrypt", and "wrapKey" with
-	// "unwrapKey" are permitted, but other combinations SHOULD NOT be used.
-	//
-	// Additional "key_ops" (key operations) values can be registered in the
-	// IANA "JSON Web CEK Plugins" registry established by Section 8.3.
-	// The same considerations about registering extension values apply to
-	// the "key_ops" member as do for the "use" member.
-	//
-	// The "use" and "key_ops" JWKCommon members SHOULD NOT be used together;
-	// however, if both are used, the information they convey MUST be
-	// consistent. Applications should specify which of these members they
-	// use, if either is to be used by the application.
 	KeyOps KeyOps `json:"key_ops,omitempty"`
-	// Alg represents the algorithm used in a JSON web key.
-	//
+	// Alg names the algorithm the key is intended to be used with.
 	// https://datatracker.ietf.org/doc/html/rfc7517#section-4.4
-	//
-	// The "alg" (algorithm) parameter identifies the algorithm intended for
-	// use with the key. The values used should either be registered in the
-	// IANA "JSON Web Signature and Encryption Algorithms" registry
-	// established by [JWA] or be a value that contains a Collision-
-	// Resistant Name. The "alg" value is a case-sensitive ASCII string.
-	// Use of this member is OPTIONAL.
 	Alg Alg `json:"alg,omitempty"`
-	// KID (Key ID) JWKCommon Parameter.
-	//
-	// https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.4
-	//
-	// The "kid" (key ID) JWKCommon Parameter is a hint indicating which key
-	// was used to secure the JWS. This parameter allows originators to
-	// explicitly signal a change of key to recipients. The structure of
-	// the "kid" value is unspecified. Its value MUST be a case-sensitive
-	// string. Use of this JWKCommon Parameter is OPTIONAL.
-	//
-	// When used with a JWKCommon, the "kid" value is used to match a JWKCommon "kid"
-	// parameter value.
+	// KID is a hint identifying which key was used, letting an originator signal
+	// a key change. When keys are matched by identifier, this is the value
+	// compared.
+	// https://datatracker.ietf.org/doc/html/rfc7517#section-4.5
 	KID string `json:"kid,omitempty"`
 }
 
-// MatchPreset is used to check is the description of a JSON Web Key matches the expected preset.
+// MatchPreset reports whether the key satisfies the given preset: it has the
+// same key type, use, and algorithm, and its operations include every one the
+// preset requires.
 func (jwk JWKCommon) MatchPreset(other JWKCommon) bool {
 	for _, keyOp := range other.KeyOps {
 		if !lo.Contains(jwk.KeyOps, keyOp) {
@@ -179,7 +53,9 @@ func (jwk JWKCommon) MatchPreset(other JWKCommon) bool {
 		jwk.Alg == other.Alg
 }
 
-// JWK represents a JSON Web Key, with both generic and key-specific information.
+// JWK is a full JSON Web Key: the common parameters plus the type-specific key
+// material carried in the payload. Marshaling merges the two into one JSON
+// object.
 type JWK struct {
 	JWKCommon
 

--- a/jwa/jwt.go
+++ b/jwa/jwt.go
@@ -6,113 +6,44 @@ import (
 	"github.com/a-novel-kit/jwt/jwa/internal"
 )
 
-// ClaimsCommon are standard claims of a JWT token.
+// ClaimsCommon holds the registered claims of a JWT, the standard fields every
+// token may carry. Application-specific claims live alongside them in the
+// payload; see Claims.
 //
 // https://datatracker.ietf.org/doc/html/rfc7519#section-4
-//
-// The JWT Claims Set represents a JSON object whose members are the
-// claims conveyed by the JWT. The Claim Names within a JWT Claims Set
-// MUST be unique; JWT parsers MUST either reject JWTs with duplicate
-// Claim Names or use a JSON parser that returns only the lexically last
-// duplicate member name, as specified in Section 15.12 ("The JSON
-// Object") of ECMAScript 5.1 [ECMAScript].
-//
-// The set of claims that a JWT must contain to be considered valid is
-// context dependent and is outside the scope of this specification.
-// Specific applications of JWTs will require implementations to
-// understand and process some claims in particular ways. However, in
-// the absence of such requirements, all claims that are not understood
-// by implementations MUST be ignored.
-//
-// There are three classes of JWT Claim Names: Registered Claim Names,
-// Public Claim Names, and Private Claim Names.
 type ClaimsCommon struct {
-	// Iss is the producer of the token.
-	//
+	// Iss identifies the issuer of the token.
 	// https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.1
-	//
-	// The "iss" (producer) claim identifies the principal that issued the
-	// JWT. The processing of this claim is generally application specific.
-	// The "iss" value is a case-sensitive string containing a StringOrURI
-	// value. Use of this claim is OPTIONAL.
 	Iss string `json:"iss,omitempty"`
-	// Sub is the subject of the token.
-	//
+	// Sub identifies the subject the claims are about. It is unique either
+	// within the issuer's scope or globally.
 	// https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.2
-	//
-	// The "sub" (subject) claim identifies the principal that is the
-	// subject of the JWT. The claims in a JWT are normally statements
-	// about the subject. The subject value MUST either be scoped to be
-	// locally unique in the context of the producer or be globally unique.
-	// The processing of this claim is generally application specific. The
-	// "sub" value is a case-sensitive string containing a StringOrURI
-	// value. Use of this claim is OPTIONAL.
 	Sub string `json:"sub,omitempty"`
-	// Aud is the audience of the token.
-	//
+	// Aud identifies the recipients the token is intended for. A recipient that
+	// does not find itself in the audience rejects the token.
 	// https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3
-	//
-	// The "aud" (audience) claim identifies the recipients that the JWT is
-	// intended for. Each principal intended to process the JWT MUST
-	// identify itself with a value in the audience claim. If the principal
-	// processing the claim does not identify itself with a value in the
-	// "aud" claim when this claim is present, then the JWT MUST be
-	// rejected. In the general case, the "aud" value is an array of case-
-	// sensitive strings, each containing a StringOrURI value. In the
-	// special case when the JWT has one audience, the "aud" value MAY be a
-	// single case-sensitive string containing a StringOrURI value. The
-	// interpretation of audience values is generally application specific.
-	// Use of this claim is OPTIONAL.
 	Aud string `json:"aud,omitempty"`
 
-	// Exp is the expiration time of the token.
-	//
+	// Exp is the time on or after which the token must not be accepted, as a
+	// Unix timestamp in seconds.
 	// https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.4
-	// The "exp" (expiration time) claim identifies the expiration time on
-	// or after which the JWT MUST NOT be accepted for processing. The
-	// processing of the "exp" claim requires that the current date/time
-	// MUST be before the expiration date/time listed in the "exp" claim.
-	// Implementers MAY provide for some small leeway, usually no more than
-	// a few minutes, to account for clock skew. Its value MUST be a number
-	// containing a NumericDate value. Use of this claim is OPTIONAL.
 	Exp int64 `json:"exp,omitempty"`
-	// Nbf is the "not before" time of the token.
-	//
+	// Nbf is the time before which the token must not be accepted, as a Unix
+	// timestamp in seconds.
 	// https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.5
-	//
-	// The "nbf" (not before) claim identifies the time before which the JWT
-	// MUST NOT be accepted for processing. The processing of the "nbf"
-	// claim requires that the current date/time MUST be after or equal to
-	// the not-before date/time listed in the "nbf" claim. Implementers MAY
-	// provide for some small leeway, usually no more than a few minutes, to
-	// account for clock skew. Its value MUST be a number containing a
-	// NumericDate value. Use of this claim is OPTIONAL.
 	Nbf int64 `json:"nbf,omitempty"`
-	// Iat is the time at which the token was issued.
-	//
+	// Iat is the time the token was issued, as a Unix timestamp in seconds.
 	// https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.6
-	//
-	// The "iat" (issued at) claim identifies the time at which the JWT was
-	// issued. This claim can be used to determine the age of the JWT. Its
-	// value MUST be a number containing a NumericDate value. Use of this
-	// claim is OPTIONAL.
 	Iat int64 `json:"iat,omitempty"`
 
-	// Jti is the JWT ID of the token.
-	//
+	// Jti is a unique identifier for the token, assigned so collisions are
+	// negligible. It lets a recipient detect a replayed token.
 	// https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.7
-	//
-	// The "jti" (JWT ID) claim provides a unique identifier for the JWT.
-	// The identifier value MUST be assigned in a manner that ensures that
-	// there is a negligible probability that the same value will be
-	// accidentally assigned to a different data object; if the application
-	// uses multiple producers, collisions MUST be prevented among values
-	// produced by different producers as well. The "jti" claim can be used
-	// to prevent the JWT from being replayed. The "jti" value is a case-
-	// sensitive string. Use of this claim is OPTIONAL.
 	Jti string `json:"jti,omitempty"`
 }
 
+// Claims is a full JWT claims set: the registered ClaimsCommon fields plus the
+// application-specific payload. Marshaling merges the two into one JSON object.
 type Claims struct {
 	ClaimsCommon
 

--- a/jwa/key_op.go
+++ b/jwa/key_op.go
@@ -1,6 +1,7 @@
 package jwa
 
-// KeyOp is used to determine the operations that can be performed with a key in a JWA protocol.
+// KeyOp is a single operation a key may perform, as listed in the "key_ops" JWK
+// parameter. The values match the KeyUsage names of the Web Cryptography API.
 type KeyOp string
 
 func (kop KeyOp) String() string {
@@ -8,24 +9,26 @@ func (kop KeyOp) String() string {
 }
 
 const (
-	// KeyOpSign compute digital signature or MAC.
+	// KeyOpSign computes a digital signature or MAC.
 	KeyOpSign KeyOp = "sign"
-	// KeyOpVerify verify digital signature or MAC.
+	// KeyOpVerify verifies a digital signature or MAC.
 	KeyOpVerify KeyOp = "verify"
-	// KeyOpEncrypt encrypt content.
+	// KeyOpEncrypt encrypts content.
 	KeyOpEncrypt KeyOp = "encrypt"
-	// KeyOpDecrypt decrypt content and validate decryption, if applicable.
+	// KeyOpDecrypt decrypts content, validating the decryption if applicable.
 	KeyOpDecrypt KeyOp = "decrypt"
-	// KeyOpWrapKey encrypt key.
+	// KeyOpWrapKey encrypts a key.
 	KeyOpWrapKey KeyOp = "wrapKey"
-	// KeyOpUnwrapKey decrypt key and validate decryption, if applicable.
+	// KeyOpUnwrapKey decrypts a key, validating the decryption if applicable.
 	KeyOpUnwrapKey KeyOp = "unwrapKey"
-	// KeyOpDeriveKey derive key.
+	// KeyOpDeriveKey derives a key.
 	KeyOpDeriveKey KeyOp = "deriveKey"
-	// KeyOpDeriveBits derive bits not to be used as a key.
+	// KeyOpDeriveBits derives bits not to be used as a key.
 	KeyOpDeriveBits KeyOp = "deriveBits"
 )
 
+// KeyOps is the set of operations a key is allowed to perform, serialized as
+// the "key_ops" JWK parameter.
 type KeyOps []KeyOp
 
 func (kop KeyOps) Strings() []string {

--- a/jwa/kty.go
+++ b/jwa/kty.go
@@ -1,44 +1,24 @@
 package jwa
 
-// KTY is used to determine the type of key in a JWA protocol.
+// KTY is the "kty" (key type) parameter of a JWK. It names the cryptographic
+// algorithm family the key belongs to.
 type KTY string
 
 func (k KTY) String() string { return string(k) }
 
 const (
-	// KTYOct Parameters for Symmetric Keys.
-	//
+	// KTYOct is a symmetric key, held as a single octet sequence.
 	// https://datatracker.ietf.org/doc/html/rfc7518#section-6.4
-	//
-	// When the JWKCommon "kty" member value is "oct" (octet sequence), the member
-	// "k" (see Section 6.4.1) is used to represent a symmetric key (or
-	// another key whose value is a single octet sequence). An "alg" member
-	// SHOULD also be present to identify the algorithm intended to be used
-	// with the key, unless the application uses another means or convention
-	// to determine the algorithm used.
 	KTYOct KTY = "oct"
-	// KTYRSA Parameters for RSA Public Keys.
-	//
+	// KTYRSA is an RSA key.
 	// https://datatracker.ietf.org/doc/html/rfc7518#section-6.3
-	//
-	// JWKs can represent RSA [RFC3447] keys. In this case, the "kty"
-	// member value is "RSA". The semantics of the parameters defined below
-	// are the same as those defined in Sections 3.1 and 3.2 of RFC 3447.
 	KTYRSA KTY = "RSA"
-	// KTYEC Parameters for Elliptic Curve Public Keys.
-	//
+	// KTYEC is an elliptic curve key.
 	// https://datatracker.ietf.org/doc/html/rfc7518#section-6.2
-	//
-	// JWKs can represent Elliptic Curve [DSS] keys. In this case, the
-	// "kty" member value is "EC".
 	KTYEC KTY = "EC"
 
-	// KTYOKP Parameters for Octet Key Pair.
-	//
+	// KTYOKP is an Octet Key Pair, used by algorithms that key on octet strings
+	// such as Ed25519 and X25519.
 	// https://datatracker.ietf.org/doc/html/rfc8037#section-2
-	//
-	// A new key type (kty) value "OKP" (Octet Key Pair) is defined for
-	// public key algorithms that use octet strings as private and public
-	// keys.
 	KTYOKP KTY = "OKP"
 )

--- a/jwa/use.go
+++ b/jwa/use.go
@@ -1,6 +1,7 @@
 package jwa
 
-// Use is used to determine the purpose of a key in a JWA protocol.
+// Use is the "use" parameter of a JWK. It marks whether the key is intended for
+// signing or for encryption.
 type Use string
 
 func (u Use) String() string { return string(u) }

--- a/jwa/x509.go
+++ b/jwa/x509.go
@@ -1,101 +1,42 @@
 package jwa
 
-// J509 represents x509 certificate information in a JSON Web Algorithm format.
+// A J509 holds the X.509 certificate parameters that a JSON Web Key may use to
+// bind its key to a certificate, as defined by RFC 7517.
 type J509 struct {
-	// X5U represents the "x5u" (X.509 URL) parameter in a JSON web key.
+	// X5U carries the "x5u" (X.509 URL) parameter, a URI referencing a resource
+	// that holds the PEM-encoded certificate or certificate chain for the key. The
+	// key in the first certificate matches the public key of the surrounding JSON
+	// Web Key.
 	//
-	// If both X5U and X5C are set, their content must be semantically consistent.
+	// When X5U and X5C are both set, they must describe the same certificate chain.
 	//
 	// https://datatracker.ietf.org/doc/html/rfc7517#section-4.6
-	//
-	// The "x5u" (X.509 URL) parameter is a URI [RFC3986] that refers to a
-	// resource for an X.509 public key certificate or certificate chain
-	// [RFC5280]. The identified resource MUST provide a representation of
-	// the certificate or certificate chain that conforms to RFC 5280
-	// [RFC5280] in PEM-encoded form, with each certificate delimited as
-	// specified in Section 6.1 of RFC 4945 [RFC4945]. The key in the first
-	// certificate MUST match the public key represented by other members of
-	// the JWKCommon. The protocol used to acquire the resource MUST provide
-	// integrity protection; an HTTP GET request to retrieve the certificate
-	// MUST use TLS [RFC2818] [RFC5246]; the identity of the server MUST be
-	// validated, as per Section 6 of RFC 6125 [RFC6125]. Use of this
-	// member is OPTIONAL.
-	//
-	// While there is no requirement that optional JWKCommon members providing key
-	// usage, algorithm, or other information be present when the "x5u"
-	// member is used, doing so may improve interoperability for
-	// applications that do not handle PKIX certificates [RFC5280]. If
-	// other members are present, the contents of those members MUST be
-	// semantically consistent with the related fields in the first
-	// certificate. For instance, if the "use" member is present, then it
-	// MUST correspond to the usage that is specified in the certificate,
-	// when it includes this information. Similarly, if the "alg" member is
-	// present, it MUST correspond to the algorithm specified in the
-	// certificate.
 	X5U string `json:"x5u,omitempty"`
-	// X5C represents the "x5c" (X.509 certificate chain) parameter in a JSON web key.
+	// X5C carries the "x5c" (X.509 certificate chain) parameter, a chain of one or
+	// more PKIX certificates encoded as base64 (not base64url) DER values. The
+	// first certificate holds the key and matches the public key of the
+	// surrounding JSON Web Key; each subsequent certificate certifies the one
+	// before it.
 	//
-	// If both X5U and X5C are set, their content must be semantically consistent.
+	// When X5U and X5C are both set, they must describe the same certificate chain.
 	//
 	// https://datatracker.ietf.org/doc/html/rfc7517#section-4.7
-	//
-	// The "x5c" (X.509 certificate chain) parameter contains a chain of one
-	// or more PKIX certificates [RFC5280]. The certificate chain is
-	// represented as a JSON array of certificate value strings. Each
-	// string in the array is a base64-encoded (Section 4 of [RFC4648] --
-	// not base64url-encoded) DER [ITU.X690.1994] PKIX certificate value.
-	// The PKIX certificate containing the key value MUST be the first
-	// certificate. This MAY be followed by additional certificates, with
-	// each subsequent certificate being the one used to certify the
-	// previous one. The key in the first certificate MUST match the public
-	// key represented by other members of the JWKCommon. Use of this member is
-	// OPTIONAL.
-	//
-	// As with the "x5u" member, optional JWKCommon members providing key usage,
-	// algorithm, or other information MAY also be present when the "x5c"
-	// member is used. If other members are present, the contents of those
-	// members MUST be semantically consistent with the related fields in
-	// the first certificate. See the last paragraph of Section 4.6 for
-	// additional guidance on this.
 	X5C []string `json:"x5c,omitempty"`
-	// X5T represents the "x5t" (X.509 certificate SHA-1 thumbprint) parameter in a JSON web key.
+	// X5T carries the "x5t" (X.509 certificate SHA-1 thumbprint) parameter, the
+	// base64url-encoded SHA-1 digest of the DER-encoded certificate.
 	//
 	// https://datatracker.ietf.org/doc/html/rfc7517#section-4.8
-	//
-	// The "x5t" (X.509 certificate SHA-1 thumbprint) parameter is a
-	// base64url-encoded SHA-1 thumbprint (a.k.a. digest) of the DER
-	// encoding of an X.509 certificate [RFC5280]. Note that certificate
-	// thumbprints are also sometimes known as certificate fingerprints.
-	// The key in the certificate MUST match the public key represented by
-	// other members of the JWKCommon. Use of this member is OPTIONAL.
-	//
-	// As with the "x5u" member, optional JWKCommon members providing key usage,
-	// algorithm, or other information MAY also be present when the "x5t"
-	// member is used. If other members are present, the contents of those
-	// members MUST be semantically consistent with the related fields in
-	// the referenced certificate. See the last paragraph of Section 4.6
-	// for additional guidance on this.
 	X5T string `json:"x5t,omitempty"`
-	// X5TS256 represents the "x5t#S256" (X.509 certificate SHA-256 thumbprint) parameter in a JSON web key.
+	// X5TS256 carries the "x5t#S256" (X.509 certificate SHA-256 thumbprint)
+	// parameter, the base64url-encoded SHA-256 digest of the DER-encoded
+	// certificate.
 	//
 	// https://datatracker.ietf.org/doc/html/rfc7517#section-4.9
-	//
-	// The "x5t#S256" (X.509 certificate SHA-256 thumbprint) parameter is a
-	// base64url-encoded SHA-256 thumbprint (a.k.a. digest) of the DER
-	// encoding of an X.509 certificate [RFC5280]. Note that certificate
-	// thumbprints are also sometimes known as certificate fingerprints.
-	// The key in the certificate MUST match the public key represented by
-	// other members of the JWKCommon. Use of this member is OPTIONAL.
-	//
-	// As with the "x5u" member, optional JWKCommon members providing key usage,
-	// algorithm, or other information MAY also be present when the
-	// "x5t#S256" member is used. If other members are present, the
-	// contents of those members MUST be semantically consistent with the
-	// related fields in the referenced certificate. See the last paragraph
-	// of Section 4.6 for additional guidance on this.
 	X5TS256 string `json:"x5t#S256,omitempty"` //nolint:tagliatelle
 }
 
+// Equal reports whether two J509 values carry identical certificate parameters.
+// A nil argument is never equal.
 func (payload *J509) Equal(other *J509) bool {
 	if other == nil {
 		return false

--- a/jwa/zip.go
+++ b/jwa/zip.go
@@ -1,9 +1,13 @@
 package jwa
 
+// Zip identifies the compression algorithm applied to a JWE plaintext before
+// encryption, carried in the "zip" header parameter.
 type Zip string
 
+// String returns the parameter value as it appears in the JWE header.
 func (z Zip) String() string { return string(z) }
 
 const (
+	// ZipDeflate selects DEFLATE compression, the "DEF" value registered by RFC 7516.
 	ZipDeflate Zip = "DEF"
 )

--- a/jwe/aes_cbc.go
+++ b/jwe/aes_cbc.go
@@ -16,6 +16,9 @@ import (
 	"github.com/a-novel-kit/jwt/jwe/internal"
 )
 
+// AESCBCPreset holds the parameters of one AES_CBC_HMAC_SHA2 variant: the enc
+// identifier, the HMAC hash, and the key and tag lengths. Use one of the package
+// presets rather than assembling this by hand.
 type AESCBCPreset struct {
 	Enc       jwa.Enc
 	Hash      crypto.Hash
@@ -26,6 +29,7 @@ type AESCBCPreset struct {
 }
 
 var (
+	// A128CBCHS256 is AES-128-CBC with HMAC-SHA-256.
 	A128CBCHS256 = AESCBCPreset{
 		Enc:       jwa.A128CBC,
 		Hash:      crypto.SHA256,
@@ -34,6 +38,7 @@ var (
 		MACKeyLen: 16,
 		TagLength: 16,
 	}
+	// A192CBCHS384 is AES-192-CBC with HMAC-SHA-384.
 	A192CBCHS384 = AESCBCPreset{
 		Enc:       jwa.A192CBC,
 		Hash:      crypto.SHA384,
@@ -42,6 +47,7 @@ var (
 		MACKeyLen: 24,
 		TagLength: 24,
 	}
+	// A256CBCHS512 is AES-256-CBC with HMAC-SHA-512.
 	A256CBCHS512 = AESCBCPreset{
 		Enc:       jwa.A256CBC,
 		Hash:      crypto.SHA512,
@@ -52,11 +58,15 @@ var (
 	}
 )
 
+// AESCBCEncryptionConfig configures NewAESCBCEncryption. CEKManager supplies the
+// content encryption key; AdditionalData, when set, is authenticated but not encrypted.
 type AESCBCEncryptionConfig struct {
 	CEKManager     CEKManager
 	AdditionalData []byte
 }
 
+// AESCBCEncryption is a jwt.ProducerPlugin that encrypts a token payload with
+// AES_CBC_HMAC_SHA2. Create it with NewAESCBCEncryption.
 type AESCBCEncryption struct {
 	cekManager     CEKManager
 	additionalData []byte
@@ -68,12 +78,9 @@ type AESCBCEncryption struct {
 	tagLength    int
 }
 
-// NewAESCBCEncryption creates a new jwt.ProducerPlugin for an encrypted token using AES_CBC_HMAC_SHA2.
-//
-// Use any of the AESCBCPreset constants to set the algorithm and hash function.
-//   - A128CBCHS256: AES-128-CBC with HMAC-SHA-256
-//   - A192CBCHS384: AES-192-CBC with HMAC-SHA-384
-//   - A256CBCHS512: AES-256-CBC with HMAC-SHA-512
+// NewAESCBCEncryption creates a jwt.ProducerPlugin that encrypts a token payload
+// with AES_CBC_HMAC_SHA2. Pass one of the package's AESCBCPreset values to select
+// the variant.
 //
 // https://datatracker.ietf.org/doc/html/rfc7518#section-5.2
 func NewAESCBCEncryption(config *AESCBCEncryptionConfig, presets AESCBCPreset) *AESCBCEncryption {
@@ -100,7 +107,7 @@ func (enc *AESCBCEncryption) Header(ctx context.Context, header *jwa.JWH) (*jwa.
 		return nil, fmt.Errorf("(AESCBCEncryption.Header) set key derivation header: %w", err)
 	}
 
-	// If the CEK CEKManager specifies an explicit enc compatibility, it must be respected.
+	// A CEKManager may pin the token to a specific enc; honor that pin rather than override it.
 	if header.Enc != "" && header.Enc != enc.enc {
 		return nil, fmt.Errorf(
 			"(AESCBCEncryption.Header) %w: cek manager is incompatible with the current encryption algorithm: "+
@@ -135,7 +142,7 @@ func (enc *AESCBCEncryption) Transform(ctx context.Context, header *jwa.JWH, raw
 		return "", fmt.Errorf("(AESCBCEncryption.Transform) encrypt key: %w", err)
 	}
 
-	// The IV used is a 128-bit value generated randomly or pseudorandomly for use in the cipher.
+	// A fresh random 128-bit IV, unique per encryption.
 	iv := make([]byte, 16)
 
 	_, err = rand.Read(iv)
@@ -143,53 +150,29 @@ func (enc *AESCBCEncryption) Transform(ctx context.Context, header *jwa.JWH, raw
 		return "", fmt.Errorf("(AESCBCEncryption.Transform) generate IV: %w", err)
 	}
 
-	// The secondary keys MAC_KEY and ENC_KEY are generated from the
-	// input key K as follows. Each of these two keys is an octet
-	// string.
-	//
-	// - MAC_KEY consists of the initial MAC_KEY_LEN octets of K, in order.
-	// - ENC_KEY consists of the final ENC_KEY_LEN octets of K, in order.
-	//
-	// The number of octets in the input key K MUST be the sum of
-	// MAC_KEY_LEN and ENC_KEY_LEN. The values of these parameters are
-	// specified by the Authenticated Encryption algorithms in Sections
-	// 5.2.3 through 5.2.5. Note that the MAC key comes before the
-	// encryption key in the input key K; this is in the opposite order
-	// of the algorithm names in the identifier "AES_CBC_HMAC_SHA2".
+	// K splits into two subkeys: MAC_KEY is its leading octets, ENC_KEY its trailing
+	// octets. The MAC key comes first, the reverse of the order the name suggests in
+	// "AES_CBC_HMAC_SHA2".
 	encKey := secret[enc.keyLength:]
 	macKey := secret[:enc.macKeyLength]
 
-	// The plaintext is CBC encrypted using PKCS #7 padding using
-	// ENC_KEY as the key and the IV.
-	block, err := aes.NewCipher(encKey) // New cipher with ENC_KEY
+	block, err := aes.NewCipher(encKey)
 	if err != nil {
 		return "", fmt.Errorf("(AESCBCEncryption.Transform) new cipher: %w", err)
 	}
 
 	blockMode := cipher.NewCBCEncrypter(block, iv)
-	// Pad the incoming data so it fits the block size.
 	origData := internal.PKCS7Padding(plainText, block.BlockSize())
-	// CipherText will hold the results of the encryption.
 	cipherText := make([]byte, len(origData))
 	blockMode.CryptBlocks(cipherText, origData)
 
-	// The octet string AL is equal to the number of bits in the
-	// Additional Authenticated Data A expressed as a 64-bit unsigned
-	// big-endian integer.
+	// AL is the additional-data length in bits as a big-endian uint64. It is the last
+	// input to the tag, so the recipient can bind the length it authenticated.
 	al := make([]byte, 8)
 	binary.BigEndian.PutUint64(al, uint64(len(enc.additionalData)*8))
 
-	// A message Authentication Tag T is computed by applying HMAC
-	// [RFC2104] to the following data, in order:
-	//
-	// - the Additional Authenticated Data A,
-	// - the Initialization Vector IV,
-	// - the ciphertext E computed in the previous step, and
-	// - the octet string AL defined above.
-	//
-	// The string MAC_KEY is used as the MAC key. We denote the output
-	// of the MAC computed in this step as M. The first T_LEN octets of
-	// M are used as T.
+	// The tag is HMAC over the additional data, IV, ciphertext, and AL in that order,
+	// truncated to tagLength octets. The order is fixed by the spec.
 	authenticationTag := hmac.New(enc.hash.New, macKey)
 	authenticationTag.Write(enc.additionalData)
 	authenticationTag.Write(iv)
@@ -226,11 +209,15 @@ func (enc *AESCBCEncryption) getCEK(ctx context.Context, header *jwa.JWH) ([]byt
 	return secret, nil
 }
 
+// AESCBCDecryptionConfig configures NewAESCBCDecryption. CEKDecoder recovers the
+// content encryption key; AdditionalData must equal the value used at encryption.
 type AESCBCDecryptionConfig struct {
 	CEKDecoder     CEKDecoder
 	AdditionalData []byte
 }
 
+// AESCBCDecryption is a jwt.RecipientPlugin that decrypts a token encrypted with
+// AES_CBC_HMAC_SHA2. Create it with NewAESCBCDecryption.
 type AESCBCDecryption struct {
 	cekDecoder     CEKDecoder
 	additionalData []byte
@@ -242,12 +229,9 @@ type AESCBCDecryption struct {
 	tagLength    int
 }
 
-// NewAESCBCDecryption creates a new jwt.RecipientPlugin for a decrypted token using AES_CBC_HMAC_SHA2.
-//
-// Use any of the AESCBCPreset constants to set the algorithm and hash function.
-//   - A128CBCHS256: AES-128-CBC with HMAC-SHA-256
-//   - A192CBCHS384: AES-192-CBC with HMAC-SHA-384
-//   - A256CBCHS512: AES-256-CBC with HMAC-SHA-512
+// NewAESCBCDecryption creates a jwt.RecipientPlugin that decrypts a token encrypted
+// with AES_CBC_HMAC_SHA2. Pass one of the package's AESCBCPreset values to select the
+// variant; it must match the one used at encryption.
 //
 // https://datatracker.ietf.org/doc/html/rfc7518#section-5.2
 func NewAESCBCDecryption(config *AESCBCDecryptionConfig, presets AESCBCPreset) *AESCBCDecryption {
@@ -311,33 +295,15 @@ func (dec *AESCBCDecryption) Transform(ctx context.Context, header *jwa.JWH, raw
 		)
 	}
 
-	// The secondary keys MAC_KEY and ENC_KEY are generated from the
-	// input key K as follows. Each of these two keys is an octet
-	// string.
-	//
-	// - MAC_KEY consists of the initial MAC_KEY_LEN octets of K, in order.
-	// - ENC_KEY consists of the final ENC_KEY_LEN octets of K, in order.
-	//
-	// The number of octets in the input key K MUST be the sum of
-	// MAC_KEY_LEN and ENC_KEY_LEN. The values of these parameters are
-	// specified by the Authenticated Encryption algorithms in Sections
-	// 5.2.3 through 5.2.5. Note that the MAC key comes before the
-	// encryption key in the input key K; this is in the opposite order
-	// of the algorithm names in the identifier "AES_CBC_HMAC_SHA2".
+	// K splits into two subkeys: MAC_KEY is its leading octets, ENC_KEY its trailing
+	// octets. The MAC key comes first, the reverse of the order the name suggests in
+	// "AES_CBC_HMAC_SHA2".
 	encKey := cek[dec.keyLength:]
 	macKey := cek[:dec.macKeyLength]
 
-	// The integrity and authenticity of A and E are checked by
-	// computing an HMAC with the inputs as in Step 5 of
-	// Section 5.2.2.1.
-	// The value T, from the previous step, is
-	// compared to the first MAC_KEY length bits of the HMAC output.  If
-	// those values are identical, then A and E are considered valid,
-	// and processing is continued.  Otherwise, all of the data used in
-	// the MAC validation are discarded, and the authenticated
-	// decryption operation returns an indication that it failed, and
-	// the operation halts.  (But see Section 11.5 of [JWE] for security
-	// considerations on thwarting timing attacks.)
+	// Recompute the tag over the same inputs as encryption and reject the token unless
+	// it matches, before touching the ciphertext. hmac.Equal compares in constant time
+	// to avoid leaking the tag through timing.
 	al := make([]byte, 8)
 	binary.BigEndian.PutUint64(al, uint64(len(dec.additionalData)*8))
 
@@ -352,9 +318,6 @@ func (dec *AESCBCDecryption) Transform(ctx context.Context, header *jwa.JWH, raw
 		return nil, fmt.Errorf("(AESCBCDecryption.Transform) %w: auth tag check failed", ErrInvalidSecret)
 	}
 
-	// The value E is decrypted and the PKCS #7 padding is checked and
-	// removed. The value IV is used as the Initialization Vector. The
-	// value ENC_KEY is used as the decryption key.
 	block, err := aes.NewCipher(encKey)
 	if err != nil {
 		return nil, fmt.Errorf("(AESCBCDecryption.Transform) new cipher: %w", err)

--- a/jwe/aes_gcm.go
+++ b/jwe/aes_gcm.go
@@ -13,31 +13,40 @@ import (
 	"github.com/a-novel-kit/jwt/jwa"
 )
 
+// AESGCMPreset holds the parameters of one AES-GCM variant: the enc identifier and
+// the key length. Use one of the package presets rather than assembling this by hand.
 type AESGCMPreset struct {
 	Enc    jwa.Enc
 	KeyLen int
 }
 
 var (
+	// A128GCM is AES-128-GCM.
 	A128GCM = AESGCMPreset{
 		Enc:    jwa.A128GCM,
 		KeyLen: 16,
 	}
+	// A192GCM is AES-192-GCM.
 	A192GCM = AESGCMPreset{
 		Enc:    jwa.A192GCM,
 		KeyLen: 24,
 	}
+	// A256GCM is AES-256-GCM.
 	A256GCM = AESGCMPreset{
 		Enc:    jwa.A256GCM,
 		KeyLen: 32,
 	}
 )
 
+// AESGCMEncryptionConfig configures NewAESGCMEncryption. CEKManager supplies the
+// content encryption key; AdditionalData, when set, is authenticated but not encrypted.
 type AESGCMEncryptionConfig struct {
 	CEKManager     CEKManager
 	AdditionalData []byte
 }
 
+// AESGCMEncryption is a jwt.ProducerPlugin that encrypts a token payload with
+// AES-GCM. Create it with NewAESGCMEncryption.
 type AESGCMEncryption struct {
 	cekManager     CEKManager
 	additionalData []byte
@@ -46,12 +55,8 @@ type AESGCMEncryption struct {
 	keyLength int
 }
 
-// NewAESGCMEncryption creates a new jwt.ProducerPlugin for an encrypted token using AES-GCM.
-//
-// Use any of the AESGCMPreset constants to set the algorithm and hash function.
-//   - A128GCM: AES-128-GCM
-//   - A192GCM: AES-192-GCM
-//   - A256GCM: AES-256-GCM
+// NewAESGCMEncryption creates a jwt.ProducerPlugin that encrypts a token payload
+// with AES-GCM. Pass one of the package's AESGCMPreset values to select the key size.
 func NewAESGCMEncryption(config *AESGCMEncryptionConfig, presets AESGCMPreset) *AESGCMEncryption {
 	return &AESGCMEncryption{
 		cekManager:     config.CEKManager,
@@ -73,7 +78,7 @@ func (enc *AESGCMEncryption) Header(ctx context.Context, header *jwa.JWH) (*jwa.
 		return nil, fmt.Errorf("(AESGCMEncryption.Header) set key derivation header: %w", err)
 	}
 
-	// If the CEK CEKManager specifies an explicit enc compatibility, it must be respected.
+	// A CEKManager may pin the token to a specific enc; honor that pin rather than override it.
 	if header.Enc != "" && header.Enc != enc.enc {
 		return nil, fmt.Errorf(
 			"(AESGCMEncryption.Header) %w: cek manager is incompatible with the current encryption algorithm: "+
@@ -108,7 +113,7 @@ func (enc *AESGCMEncryption) Transform(ctx context.Context, header *jwa.JWH, raw
 		return "", fmt.Errorf("(AESGCMEncryption.Transform) encrypt key: %w", err)
 	}
 
-	// The IV used is a 128-bit value generated randomly or pseudorandomly for use in the cipher.
+	// A fresh random 96-bit nonce, the length NewGCM expects by default.
 	iv := make([]byte, 12)
 
 	_, err = rand.Read(iv)
@@ -126,8 +131,9 @@ func (enc *AESGCMEncryption) Transform(ctx context.Context, header *jwa.JWH, raw
 		return "", fmt.Errorf("(AESGCMEncryption.Transform) create gcm: %w", err)
 	}
 
+	// Seal appends the authentication tag to the ciphertext; JWE carries them in
+	// separate fields, so split off the trailing Overhead() bytes.
 	ciphertextAndTag := aesgcm.Seal(nil, iv, plainText, enc.additionalData)
-	// Separate the actual cipherText from the authentication tag.
 	cipherLen := len(ciphertextAndTag) - aesgcm.Overhead()
 	cipherText := ciphertextAndTag[:cipherLen]
 	tag := ciphertextAndTag[cipherLen:]
@@ -161,11 +167,15 @@ func (enc *AESGCMEncryption) getCEK(ctx context.Context, header *jwa.JWH) ([]byt
 	return secret, nil
 }
 
+// AESGCMDecryptionConfig configures NewAESGCMDecryption. CEKDecoder recovers the
+// content encryption key; AdditionalData must equal the value used at encryption.
 type AESGCMDecryptionConfig struct {
 	CEKDecoder     CEKDecoder
 	AdditionalData []byte
 }
 
+// AESGCMDecryption is a jwt.RecipientPlugin that decrypts a token encrypted with
+// AES-GCM. Create it with NewAESGCMDecryption.
 type AESGCMDecryption struct {
 	cekDecoder     CEKDecoder
 	additionalData []byte
@@ -174,12 +184,9 @@ type AESGCMDecryption struct {
 	keyLength int
 }
 
-// NewAESGCMDecryption creates a new jwt.RecipientPlugin for an encrypted token using AES-GCM.
-//
-// Use any of the AESGCMPreset constants to set the algorithm and hash function.
-//   - A128GCM: AES-128-GCM
-//   - A192GCM: AES-192-GCM
-//   - A256GCM: AES-256-GCM
+// NewAESGCMDecryption creates a jwt.RecipientPlugin that decrypts a token encrypted
+// with AES-GCM. Pass one of the package's AESGCMPreset values to select the key size;
+// it must match the one used at encryption.
 func NewAESGCMDecryption(config *AESGCMDecryptionConfig, presets AESGCMPreset) *AESGCMDecryption {
 	return &AESGCMDecryption{
 		cekDecoder:     config.CEKDecoder,

--- a/jwe/common.go
+++ b/jwe/common.go
@@ -2,4 +2,7 @@ package jwe
 
 import "errors"
 
+// ErrInvalidSecret is returned when the content encryption key resolved for a token
+// has the wrong length for the chosen algorithm, or when an authentication tag fails
+// to verify during decryption.
 var ErrInvalidSecret = errors.New("invalid secret")

--- a/jwe/internal/concat_kdf.go
+++ b/jwe/internal/concat_kdf.go
@@ -1,10 +1,16 @@
+// Package internal holds the low-level cryptographic primitives that the JWE key-management
+// algorithms compose: key derivation, key wrapping, and padding. They live here so several
+// algorithm implementations can share one vetted implementation of each primitive instead of
+// duplicating it.
 package internal
 
 import (
 	"crypto"
 )
 
-// ConcatKDF implementation, as defined in Section 5.8.1 of [NIST.800-56A].
+// ConcatKDF derives keyDataLen bytes of key material from the shared secret z, following the
+// single-step Concatenation KDF defined in NIST SP 800-56A. The remaining arguments are hashed
+// alongside z on every iteration as the KDF's OtherInfo.
 func ConcatKDF(
 	hash crypto.Hash, z []byte, keyDataLen int, algID, pUInfo, pVInfo, supPubInfo, supPrivInfo []byte,
 ) []byte {

--- a/jwe/internal/derive_key.go
+++ b/jwe/internal/derive_key.go
@@ -7,54 +7,34 @@ import (
 	"fmt"
 )
 
+// ErrDataTooLarge is returned when an input length exceeds the 32-bit field used to encode it in a
+// length-prefixed KDF block.
 var ErrDataTooLarge = errors.New("data is too large")
 
-// Derive a key from a shared secret.
-//
-// Alg is the algorithm ID.  In the Direct Key Agreement case, Data is set to the octets of the ASCII representation
-// of the "enc" Header Parameter value. In the Key Agreement with Key Wrapping case, Data is set to the octets of the
-// ASCII representation of the "alg" (algorithm) Header Parameter value.
-//
-// Key size is set to the number of bits in the desired output key. For "ECDH-ES", this is length of the key used by
-// the "enc" algorithm. For "ECDH-ES+A128KW", "ECDH-ES+A192KW", and "ECDH-ES+A256KW", this is 128, 192, and 256,
-// respectively.
-//
-// Apu is the Agreement PartyUInfo value. If an "apu" (agreement PartyUInfo) Header Parameter is present, Data is set
-// to the result of base64url decoding the "apu" value and Datalen is set to the number of octets in Data. Otherwise,
-// Datalen is set to 0 and Data is set to the empty octet sequence.
-//
-// Apv is the Agreement PartyVInfo value. If an "apv" (agreement PartyVInfo) Header Parameter is present, Data is set
-// to the result of base64url decoding the "apv" value and Datalen is set to the number of octets in Data. Otherwise,
-// Datalen is set to 0 and Data is set to the empty octet sequence.
+// Derive computes a key of keySize bytes from the ECDH shared secret z, following the ECDH-ES key
+// agreement of RFC 7518. alg is the algorithm identifier bound into the derivation: the "enc" value
+// for Direct Key Agreement, or the "alg" value when the derived key wraps the content key. apu and
+// apv are the already base64url-decoded PartyUInfo and PartyVInfo agreement parameters, either of
+// which may be empty.
 func Derive(z []byte, alg string, keySize int, apu, apv string) ([]byte, error) {
-	// The AlgorithmID value is of the form Datalen || Data, where Data
-	// is a variable-length string of zero or more octets, and Datalen is
-	// a fixed-length, big-endian 32-bit counter that indicates the
-	// length (in octets) of Data.
+	// AlgorithmID, PartyUInfo, and PartyVInfo make up the ConcatKDF OtherInfo, each carried as a
+	// length-prefixed block.
 	algID, err := prefixBlock([]byte(alg))
 	if err != nil {
 		return nil, fmt.Errorf("prefix algID: %w", err)
 	}
 
-	// The PartyUInfo value is of the form Datalen || Data, where Data is
-	// a variable-length string of zero or more octets, and Datalen is a
-	// fixed-length, big-endian 32-bit counter that indicates the length
-	// (in octets) of Data.
 	ptyUInfo, err := prefixBlock([]byte(apu))
 	if err != nil {
 		return nil, fmt.Errorf("prefix ptyUInfo: %w", err)
 	}
 
-	// The PartyVInfo value is of the form Datalen || Data, where Data is
-	// a variable-length string of zero or more octets, and Datalen is a
-	// fixed-length, big-endian 32-bit counter that indicates the length
-	// (in octets) of Data.
 	ptyVInfo, err := prefixBlock([]byte(apv))
 	if err != nil {
 		return nil, fmt.Errorf("prefix ptyVInfo: %w", err)
 	}
 
-	// This is set to the keydatalen represented as a 32-bit big-endian integer.
+	// SuppPubInfo carries the output key length in bits as a 32-bit big-endian integer.
 	supPubInfo := make([]byte, 4)
 
 	if keySize > 0xFFFFFFF {
@@ -63,14 +43,15 @@ func Derive(z []byte, alg string, keySize int, apu, apv string) ([]byte, error) 
 
 	binary.BigEndian.PutUint32(supPubInfo, uint32(keySize*8))
 
-	// This is set to the empty octet sequence.
+	// SuppPrivInfo is unused here and stays empty.
 	var supPrivInfo []byte
 
-	// Derive the shared key.
 	return ConcatKDF(crypto.SHA256, z, keySize, algID, ptyUInfo, ptyVInfo, supPubInfo, supPrivInfo), nil
 }
 
-// Prefix the input data with a 32-bit big-endian length.
+// prefixBlock returns data prefixed with its length as a 32-bit big-endian integer, the
+// Datalen || Data framing that ConcatKDF's OtherInfo fields require. It fails if data is longer than
+// that length field can encode.
 func prefixBlock(data []byte) ([]byte, error) {
 	out := make([]byte, len(data)+4)
 

--- a/jwe/internal/key_wrap.go
+++ b/jwe/internal/key_wrap.go
@@ -7,12 +7,13 @@ import (
 	"errors"
 )
 
-// Shamelessly stolen
+// Adapted from go-jose:
 // https://github.com/go-jose/go-jose/blob/fdc2ceb0bbe2a29c582edfe07ea914c8dacd7e1b/cipher/key_wrap.go
 
 var defaultIV = []byte{0xA6, 0xA6, 0xA6, 0xA6, 0xA6, 0xA6, 0xA6, 0xA6}
 
-// KeyWrap implements NIST key wrapping; it wraps a content encryption key (cek) with the given block cipher.
+// KeyWrap wraps the content encryption key cek under block using the AES Key Wrap algorithm
+// (RFC 3394). The cek length must be a multiple of 8 bytes.
 func KeyWrap(block cipher.Block, cek []byte) ([]byte, error) {
 	if len(cek)%8 != 0 {
 		return nil, errors.New("key wrap input must be 8 byte blocks")
@@ -55,7 +56,8 @@ func KeyWrap(block cipher.Block, cek []byte) ([]byte, error) {
 	return out, nil
 }
 
-// KeyUnwrap implements NIST key unwrapping; it unwraps a content encryption key (cek) with the given block cipher.
+// KeyUnwrap reverses KeyWrap, recovering the content encryption key from ciphertext under block. It
+// fails when the integrity check value does not match, which signals a wrong key or corrupted input.
 func KeyUnwrap(block cipher.Block, ciphertext []byte) ([]byte, error) {
 	if len(ciphertext)%8 != 0 {
 		return nil, errors.New("key wrap input must be 8 byte blocks")

--- a/jwe/internal/pkcs.go
+++ b/jwe/internal/pkcs.go
@@ -4,9 +4,8 @@ import (
 	"bytes"
 )
 
-// https://stackoverflow.com/a/41595640/9021186
-
-// PKCS7Padding pads the given ciphertext to the nearest multiple of the block size.
+// PKCS7Padding appends PKCS#7 padding to bring ciphertext up to a whole multiple of blockSize. A
+// full block is added when the input is already aligned, so the padding is always removable.
 func PKCS7Padding(ciphertext []byte, blockSize int) []byte {
 	padding := blockSize - len(ciphertext)%blockSize
 	padtext := bytes.Repeat([]byte{byte(padding)}, padding)
@@ -14,7 +13,7 @@ func PKCS7Padding(ciphertext []byte, blockSize int) []byte {
 	return append(ciphertext, padtext...)
 }
 
-// PKCS7UnPadding removes the padding from the given ciphertext.
+// PKCS7UnPadding strips the PKCS#7 padding that PKCS7Padding added, returning the original plaintext.
 func PKCS7UnPadding(plaintText []byte) []byte {
 	length := len(plaintText)
 	unpadding := int(plaintText[length-1])

--- a/jwe/jwek/aes_gcm_key_wrap.go
+++ b/jwe/jwek/aes_gcm_key_wrap.go
@@ -13,11 +13,14 @@ import (
 	"github.com/a-novel-kit/jwt/jwa"
 )
 
+// AESGCMKWPreset pairs a JWA algorithm identifier with its wrap-key length. Use
+// one of the predefined presets rather than building one by hand.
 type AESGCMKWPreset struct {
 	Alg    jwa.Alg
 	KeyLen int
 }
 
+// The AES GCM key-wrap presets, one per supported wrap-key length.
 var (
 	A128GCMKW = AESGCMKWPreset{
 		Alg:    jwa.A128GCMKW,
@@ -33,11 +36,15 @@ var (
 	}
 )
 
+// AESGCMKWManagerConfig holds the inputs for NewAESGCMKWManager: the content
+// encryption key to protect and the key that wraps it.
 type AESGCMKWManagerConfig struct {
 	CEK     []byte
 	WrapKey []byte
 }
 
+// AESGCMKWManager implements jwe.CEKManager, wrapping the content encryption key
+// with AES GCM. See RFC 7518 section 4.7.
 type AESGCMKWManager struct {
 	cek     []byte
 	wrapKey []byte
@@ -46,12 +53,9 @@ type AESGCMKWManager struct {
 	keyLen int
 }
 
-// NewAESGCMKWManager creates a new jwe.CEKManager for a key derived using AES GCM Key Wrap.
-//
-// Use any of the AESGCMKWPreset constants to set the algorithm and key length.
-//   - A128GCMKW: 16 bytes key length
-//   - A192GCMKW: 24 bytes key length
-//   - A256GCMKW: 32 bytes key length
+// NewAESGCMKWManager creates a jwe.CEKManager that wraps the content encryption
+// key with AES GCM. The preset selects the algorithm and wrap-key length; use one
+// of the AESGCMKWPreset values (for example A128GCMKW).
 //
 // https://datatracker.ietf.org/doc/html/rfc7518#section-4.7
 func NewAESGCMKWManager(
@@ -105,7 +109,8 @@ func (manager *AESGCMKWManager) EncryptCEK(_ context.Context, header *jwa.JWH, c
 	}
 
 	ciphertextAndTag := aesgcm.Seal(nil, iv, cek, []byte{})
-	// Separate the actual cipherText from the authentication tag.
+	// Seal appends the authentication tag to the ciphertext; the JWE header carries
+	// the tag separately, so split the two apart here.
 	cipherLen := len(ciphertextAndTag) - aesgcm.Overhead()
 	ciphertext := ciphertextAndTag[:cipherLen]
 	tag := ciphertextAndTag[cipherLen:]
@@ -126,22 +131,23 @@ func (manager *AESGCMKWManager) EncryptCEK(_ context.Context, header *jwa.JWH, c
 	return ciphertext, nil
 }
 
+// AESGCMKWDecoderConfig holds the key-wrapping key used to unwrap a content
+// encryption key.
 type AESGCMKWDecoderConfig struct {
 	WrapKey []byte
 }
 
+// AESGCMKWDecoder implements jwe.CEKDecoder, unwrapping a content encryption key
+// that was wrapped with AES GCM.
 type AESGCMKWDecoder struct {
 	wrapKey []byte
 	alg     jwa.Alg
 	keyLen  int
 }
 
-// NewAESGCMKWDecoder creates a new jwe.CEKDecoder for a key derived using AES GCM Key Wrap.
-//
-// Use any of the AESGCMKWPreset constants to set the algorithm and key length.
-//   - A128GCMKW: 16 bytes key length
-//   - A192GCMKW: 24 bytes key length
-//   - A256GCMKW: 32 bytes key length
+// NewAESGCMKWDecoder creates a jwe.CEKDecoder that unwraps an AES GCM wrapped
+// content encryption key. The preset must match the one used to wrap it; use one
+// of the AESGCMKWPreset values (for example A128GCMKW).
 //
 // https://datatracker.ietf.org/doc/html/rfc7518#section-4.7
 func NewAESGCMKWDecoder(config *AESGCMKWDecoderConfig, preset AESGCMKWPreset) *AESGCMKWDecoder {

--- a/jwe/jwek/aes_key_wrap.go
+++ b/jwe/jwek/aes_key_wrap.go
@@ -10,11 +10,14 @@ import (
 	"github.com/a-novel-kit/jwt/jwe/internal"
 )
 
+// AESKWPreset pairs a JWA algorithm identifier with its wrap-key length. Use one
+// of the predefined presets rather than building one by hand.
 type AESKWPreset struct {
 	Alg    jwa.Alg
 	KeyLen int
 }
 
+// The AES key-wrap presets, one per supported wrap-key length.
 var (
 	A128KW = AESKWPreset{
 		Alg:    jwa.A128KW,
@@ -30,11 +33,15 @@ var (
 	}
 )
 
+// AESKWManagerConfig holds the inputs for NewAESKWManager: the content encryption
+// key to protect and the key that wraps it.
 type AESKWManagerConfig struct {
 	CEK     []byte
 	WrapKey []byte
 }
 
+// AESKWManager implements jwe.CEKManager, wrapping the content encryption key with
+// the AES Key Wrap algorithm. See RFC 7518 section 4.4.
 type AESKWManager struct {
 	cek     []byte
 	wrapKey []byte
@@ -43,12 +50,9 @@ type AESKWManager struct {
 	keyLen int
 }
 
-// NewAESKWManager creates a new jwe.CEKManager for a key derived using AES Key Wrap.
-//
-// Use any of the AESKWPreset constants to set the algorithm and key length.
-//   - A128KW: 16 bytes key length
-//   - A192KW: 24 bytes key length
-//   - A256KW: 32 bytes key length
+// NewAESKWManager creates a jwe.CEKManager that wraps the content encryption key
+// with AES Key Wrap. The preset selects the algorithm and wrap-key length; use one
+// of the AESKWPreset values (for example A128KW).
 //
 // https://datatracker.ietf.org/doc/html/rfc7518#section-4.4
 func NewAESKWManager(config *AESKWManagerConfig, preset AESKWPreset) *AESKWManager {
@@ -95,10 +99,14 @@ func (manager *AESKWManager) EncryptCEK(_ context.Context, _ *jwa.JWH, cek []byt
 	return wrapped, nil
 }
 
+// AESKWDecoderConfig holds the key-wrapping key used to unwrap a content
+// encryption key.
 type AESKWDecoderConfig struct {
 	WrapKey []byte
 }
 
+// AESKWDecoder implements jwe.CEKDecoder, unwrapping a content encryption key that
+// was wrapped with AES Key Wrap.
 type AESKWDecoder struct {
 	wrapKey []byte
 
@@ -106,12 +114,9 @@ type AESKWDecoder struct {
 	keyLen int
 }
 
-// NewAESKWDecoder creates a new jwe.CEKDecoder for a key derived using AES Key Wrap.
-//
-// Use any of the AESKWPreset constants to set the algorithm and key length.
-//   - A128KW: 16 bytes key length
-//   - A192KW: 24 bytes key length
-//   - A256KW: 32 bytes key length
+// NewAESKWDecoder creates a jwe.CEKDecoder that unwraps an AES Key Wrap wrapped
+// content encryption key. The preset must match the one used to wrap it; use one
+// of the AESKWPreset values (for example A128KW).
 //
 // https://datatracker.ietf.org/doc/html/rfc7518#section-4.4
 func NewAESKWDecoder(secret *AESKWDecoderConfig, preset AESKWPreset) *AESKWDecoder {

--- a/jwe/jwek/direct_encryption.go
+++ b/jwe/jwek/direct_encryption.go
@@ -8,11 +8,15 @@ import (
 	"github.com/a-novel-kit/jwt/jwa"
 )
 
+// DirectKeyManager implements jwe.CEKManager for direct encryption: the content
+// encryption key is a shared secret used as-is, so nothing is wrapped into the
+// token. See RFC 7518 section 4.5.
 type DirectKeyManager struct {
 	cek []byte
 }
 
-// NewDirectKeyManager creates a new instance of DirectKeyManager.
+// NewDirectKeyManager creates a jwe.CEKManager that uses the given content
+// encryption key directly, without wrapping it into the token.
 //
 // https://datatracker.ietf.org/doc/html/rfc7518#section-4.5
 func NewDirectKeyManager(cek []byte) *DirectKeyManager {
@@ -39,15 +43,20 @@ func (manager *DirectKeyManager) EncryptCEK(_ context.Context, _ []byte) ([]byte
 	return nil, nil
 }
 
+// DirectKeyDecoderConfig holds the shared content encryption key used to decrypt
+// the token.
 type DirectKeyDecoderConfig struct {
 	CEK []byte
 }
 
+// DirectKeyDecoder implements jwe.CEKDecoder for direct encryption, returning the
+// shared content encryption key it was configured with.
 type DirectKeyDecoder struct {
 	cek []byte
 }
 
-// NewDirectKeyDecoder creates a new instance of DirectKeyDecoder.
+// NewDirectKeyDecoder creates a jwe.CEKDecoder that decrypts tokens with the given
+// shared content encryption key.
 //
 // https://datatracker.ietf.org/doc/html/rfc7518#section-4.5
 func NewDirectKeyDecoder(config *DirectKeyDecoderConfig) *DirectKeyDecoder {

--- a/jwe/jwek/key_derivation_ecdh.go
+++ b/jwe/jwek/key_derivation_ecdh.go
@@ -14,12 +14,17 @@ import (
 	"github.com/a-novel-kit/jwt/jwk/serializers"
 )
 
+// ECDHKeyAgrPreset binds a content-encryption algorithm to its derived-key length
+// for ECDH-ES key agreement. Each preset targets one specific encryption and is
+// not interchangeable. Use one of the predefined presets rather than building one
+// by hand.
 type ECDHKeyAgrPreset struct {
 	Enc    jwa.Enc
 	Alg    jwa.Alg
 	KeyLen int
 }
 
+// The ECDH-ES presets, one per supported content-encryption algorithm.
 var (
 	ECDHESA128CBC = ECDHKeyAgrPreset{
 		Enc:    jwa.A128CBC,
@@ -48,6 +53,10 @@ var (
 	}
 )
 
+// ECDHKeyAgrManagerConfig holds the inputs for NewECDHKeyAgrManager. ProducerKey
+// and RecipientKey are the two halves of the Diffie-Hellman exchange; ProducerInfo
+// and RecipientInfo are the optional agreement party details mixed into the key
+// derivation.
 type ECDHKeyAgrManagerConfig struct {
 	ProducerKey  *ecdh.PrivateKey
 	RecipientKey *ecdh.PublicKey
@@ -56,6 +65,9 @@ type ECDHKeyAgrManagerConfig struct {
 	RecipientInfo string
 }
 
+// ECDHKeyAgrManager implements jwe.CEKManager for ECDH-ES key agreement: it derives
+// the content encryption key from a shared secret instead of wrapping one into the
+// token. See RFC 7518 section 4.6.
 type ECDHKeyAgrManager struct {
 	config ECDHKeyAgrManagerConfig
 
@@ -63,23 +75,14 @@ type ECDHKeyAgrManager struct {
 	keyLen int
 }
 
-// NewECDHKeyAgrManager creates a new jwe.CEKManager factory for a key derivation using ECDH.
+// NewECDHKeyAgrManager creates a jwe.CEKManager that derives the content
+// encryption key with ECDH-ES using the Concat KDF. The preset selects the
+// content-encryption algorithm and derived-key length; use one of the
+// ECDHKeyAgrPreset values (for example ECDHESA128CBC).
 //
-// Use any of the ECDHKeyAgrPreset constants to set the algorithm and key length.
-//   - ECDHESA128CBC: ECDH-ES using Concat KDF and CEK length of 128 bits
-//   - ECDHESA192CBC: ECDH-ES using Concat KDF and CEK length of 192 bits
-//   - ECDHESA256CBC: ECDH-ES using Concat KDF and CEK length of 256 bits
-//   - ECDHESA128GCM: ECDH-ES using Concat KDF and CEK length of 128 bits
-//   - ECDHESA192GCM: ECDH-ES using Concat KDF and CEK length of 192 bits
-//   - ECDHESA256GCM: ECDH-ES using Concat KDF and CEK length of 256 bits
-//
-// This manager is NOT encryption agnostic.
-//   - ECDHESA128CBC requires jwe.A128CBCHS256 encryption
-//   - ECDHESA192CBC requires jwe.A192CBCHS384 encryption
-//   - ECDHESA256CBC requires jwe.A256CBCHS512 encryption
-//   - ECDHESA128GCM requires jwe.A128GCM encryption
-//   - ECDHESA192GCM requires jwe.A192GCM encryption
-//   - ECDHESA256GCM requires jwe.A256GCM encryption
+// The preset is bound to a specific jwe encryption and is not interchangeable:
+// pick the encryption whose name matches the preset (for example ECDHESA128CBC
+// pairs with jwe.A128CBCHS256).
 //
 // https://datatracker.ietf.org/doc/html/rfc7518#section-4.6
 func NewECDHKeyAgrManager(config *ECDHKeyAgrManagerConfig, preset ECDHKeyAgrPreset) *ECDHKeyAgrManager {
@@ -95,8 +98,8 @@ func (manager *ECDHKeyAgrManager) SetHeader(_ context.Context, header *jwa.JWH) 
 		return nil, fmt.Errorf("(ECDHKeyAgrManager.SetHeader) %w: alg field already set", jwt.ErrConflictingHeader)
 	}
 
-	// Share the producer public key to the recipient. Each party requires the other one's public key in order to
-	// derive the shared secret.
+	// Publish the producer public key in the header: the recipient needs it to
+	// derive the same shared secret from its own private key.
 	publicKeyEncoded, err := serializers.EncodeECDH(manager.config.ProducerKey.PublicKey())
 	if err != nil {
 		return nil, fmt.Errorf("(ECDHKeyAgrManager.SetHeader) encode public key: %w", err)
@@ -136,10 +139,14 @@ func (manager *ECDHKeyAgrManager) EncryptCEK(_ context.Context, _ *jwa.JWH, _ []
 	return nil, nil
 }
 
+// ECDHKeyAgrDecoderConfig holds the recipient private key used to reconstruct the
+// shared secret from the producer public key carried in the token header.
 type ECDHKeyAgrDecoderConfig struct {
 	RecipientKey *ecdh.PrivateKey
 }
 
+// ECDHKeyAgrDecoder implements jwe.CEKDecoder for ECDH-ES key agreement, deriving
+// the content encryption key from the shared secret. See RFC 7518 section 4.6.
 type ECDHKeyAgrDecoder struct {
 	config ECDHKeyAgrDecoderConfig
 
@@ -147,23 +154,14 @@ type ECDHKeyAgrDecoder struct {
 	keyLen int
 }
 
-// NewECDHKeyAgrDecoder creates a new jwe.CEKDecoder factory for a key derivation using ECDH.
+// NewECDHKeyAgrDecoder creates a jwe.CEKDecoder that derives the content
+// encryption key with ECDH-ES using the Concat KDF. The preset must match the one
+// used to encrypt the token; use one of the ECDHKeyAgrPreset values (for example
+// ECDHESA128CBC).
 //
-// Use any of the ECDHKeyAgrPreset constants to set the algorithm and key length.
-//   - ECDHESA128CBC: ECDH-ES using Concat KDF and CEK length of 128 bits
-//   - ECDHESA192CBC: ECDH-ES using Concat KDF and CEK length of 192 bits
-//   - ECDHESA256CBC: ECDH-ES using Concat KDF and CEK length of 256 bits
-//   - ECDHESA128GCM: ECDH-ES using Concat KDF and CEK length of 128 bits
-//   - ECDHESA192GCM: ECDH-ES using Concat KDF and CEK length of 192 bits
-//   - ECDHESA256GCM: ECDH-ES using Concat KDF and CEK length of 256 bits
-//
-// This manager is NOT encryption agnostic.
-//   - ECDHESA128CBC requires jwe.A128CBCHS256 encryption
-//   - ECDHESA192CBC requires jwe.A192CBCHS384 encryption
-//   - ECDHESA256CBC requires jwe.A256CBCHS512 encryption
-//   - ECDHESA128GCM requires jwe.A128GCM encryption
-//   - ECDHESA192GCM requires jwe.A192GCM encryption
-//   - ECDHESA256GCM requires jwe.A256GCM encryption
+// The preset is bound to a specific jwe encryption and is not interchangeable:
+// pick the encryption whose name matches the preset (for example ECDHESA128CBC
+// pairs with jwe.A128CBCHS256).
 //
 // https://datatracker.ietf.org/doc/html/rfc7518#section-4.6
 func NewECDHKeyAgrDecoder(config *ECDHKeyAgrDecoderConfig, preset ECDHKeyAgrPreset) *ECDHKeyAgrDecoder {

--- a/jwe/jwek/key_derivation_ecdh_kw.go
+++ b/jwe/jwek/key_derivation_ecdh_kw.go
@@ -15,11 +15,15 @@ import (
 	"github.com/a-novel-kit/jwt/jwk/serializers"
 )
 
+// ECDHKeyAgrKWPreset pairs a JWA algorithm identifier with the length of the
+// key-wrapping key derived from the shared secret. Use one of the predefined
+// presets rather than building one by hand.
 type ECDHKeyAgrKWPreset struct {
 	Alg    jwa.Alg
 	KeyLen int
 }
 
+// The ECDH-ES with AES Key Wrap presets, one per supported wrap-key length.
 var (
 	ECDHESA128KW = ECDHKeyAgrKWPreset{
 		Alg:    jwa.ECDHESA128KW,
@@ -35,6 +39,10 @@ var (
 	}
 )
 
+// ECDHKeyAgrKWManagerConfig holds the inputs for NewECDHKeyAgrKWManager.
+// ProducerKey and RecipientKey are the two halves of the Diffie-Hellman exchange,
+// CEK is the content encryption key to wrap, and ProducerInfo and RecipientInfo
+// are the optional agreement party details mixed into the key derivation.
 type ECDHKeyAgrKWManagerConfig struct {
 	ProducerKey  *ecdh.PrivateKey
 	RecipientKey *ecdh.PublicKey
@@ -45,6 +53,8 @@ type ECDHKeyAgrKWManagerConfig struct {
 	RecipientInfo string
 }
 
+// ECDHKeyAgrKWManager implements jwe.CEKManager: it derives a key-wrapping key with
+// ECDH-ES and then wraps the content encryption key with AES Key Wrap.
 type ECDHKeyAgrKWManager struct {
 	config ECDHKeyAgrKWManagerConfig
 
@@ -52,12 +62,12 @@ type ECDHKeyAgrKWManager struct {
 	keyLen int
 }
 
-// NewECDHKeyAgrKWManager creates a new jwe.CEKManager for a key derivation using ECDH and AES Key Wrap.
+// NewECDHKeyAgrKWManager creates a jwe.CEKManager that derives a key-wrapping key
+// with ECDH-ES (Concat KDF) and wraps the content encryption key with AES Key Wrap.
+// The preset selects the algorithm and wrap-key length; use one of the
+// ECDHKeyAgrKWPreset values (for example ECDHESA128KW).
 //
-// Use any of the ECDHKeyAgrKWPreset constants to set the algorithm and key length.
-//   - ECDHESA128KW: ECDH-ES using Concat KDF and AES Key Wrap with AES-CBC-HMAC-SHA2
-//   - ECDHESA192KW: ECDH-ES using Concat KDF and AES Key Wrap with AES-CBC-HMAC-SHA2
-//   - ECDHESA256KW: ECDH-ES using Concat KDF and AES Key Wrap with AES-CBC-HMAC-SHA2
+// https://datatracker.ietf.org/doc/html/rfc7518#section-4.6
 func NewECDHKeyAgrKWManager(
 	config *ECDHKeyAgrKWManagerConfig, preset ECDHKeyAgrKWPreset,
 ) *ECDHKeyAgrKWManager {
@@ -73,8 +83,8 @@ func (manager *ECDHKeyAgrKWManager) SetHeader(_ context.Context, header *jwa.JWH
 		return nil, fmt.Errorf("(ECDHKeyAgrKWManager.SetHeader) %w: alg field already set", jwt.ErrConflictingHeader)
 	}
 
-	// Share the producer public key to the recipient. Each party requires the other one's public key in order to
-	// derive the shared secret.
+	// Publish the producer public key in the header: the recipient needs it to
+	// derive the same shared secret from its own private key.
 	publicKeyEncoded, err := serializers.EncodeECDH(manager.config.ProducerKey.PublicKey())
 	if err != nil {
 		return nil, fmt.Errorf("(ECDHKeyAgrKWManager.SetHeader) encode public key: %w", err)
@@ -123,10 +133,14 @@ func (manager *ECDHKeyAgrKWManager) EncryptCEK(_ context.Context, header *jwa.JW
 	return wrapped, nil
 }
 
+// ECDHKeyAgrKWDecoderConfig holds the recipient private key used to reconstruct the
+// shared secret from the producer public key carried in the token header.
 type ECDHKeyAgrKWDecoderConfig struct {
 	RecipientKey *ecdh.PrivateKey
 }
 
+// ECDHKeyAgrKWDecoder implements jwe.CEKDecoder: it re-derives the key-wrapping key
+// with ECDH-ES and unwraps the content encryption key with AES Key Wrap.
 type ECDHKeyAgrKWDecoder struct {
 	config ECDHKeyAgrKWDecoderConfig
 
@@ -134,12 +148,12 @@ type ECDHKeyAgrKWDecoder struct {
 	keyLen int
 }
 
-// NewECDHKeyAgrKWDecoder creates a new jwe.CEKDecoder factory for a key derivation using ECDH and AES Key Wrap.
+// NewECDHKeyAgrKWDecoder creates a jwe.CEKDecoder that re-derives the key-wrapping
+// key with ECDH-ES (Concat KDF) and unwraps the content encryption key with AES Key
+// Wrap. The preset must match the one used to encrypt the token; use one of the
+// ECDHKeyAgrKWPreset values (for example ECDHESA128KW).
 //
-// Use any of the ECDHKeyAgrKWPreset constants to set the algorithm and key length.
-//   - ECDHESA128KW: ECDH-ES using Concat KDF and AES Key Wrap with AES-CBC-HMAC-SHA2
-//   - ECDHESA192KW: ECDH-ES using Concat KDF and AES Key Wrap with AES-CBC-HMAC-SHA2
-//   - ECDHESA256KW: ECDH-ES using Concat KDF and AES Key Wrap with AES-CBC-HMAC-SHA2
+// https://datatracker.ietf.org/doc/html/rfc7518#section-4.6
 func NewECDHKeyAgrKWDecoder(config *ECDHKeyAgrKWDecoderConfig, preset ECDHKeyAgrKWPreset) *ECDHKeyAgrKWDecoder {
 	return &ECDHKeyAgrKWDecoder{
 		config: *config,

--- a/jwe/jwek/pbes2_key_enc.go
+++ b/jwe/jwek/pbes2_key_enc.go
@@ -15,12 +15,16 @@ import (
 	"github.com/a-novel-kit/jwt/jwe/internal"
 )
 
+// PBES2KeyEncKWPreset pairs a JWA algorithm identifier with the hash and key size
+// used to derive the wrap key from the password. Use one of the predefined presets
+// rather than building one by hand.
 type PBES2KeyEncKWPreset struct {
 	Alg     jwa.Alg
 	Hash    crypto.Hash
 	KeySize int
 }
 
+// The PBES2 presets, one per supported hash and key size.
 var (
 	PBES2A128KW = PBES2KeyEncKWPreset{
 		Alg:     jwa.PBES2HS256A128KW,
@@ -39,21 +43,26 @@ var (
 	}
 )
 
+// PBES2KeyEncKWManagerConfig holds the inputs for NewPBES2KeyEncKWManager.
 type PBES2KeyEncKWManagerConfig struct {
-	// The iteration count adds computational expense, ideally compounded by
-	// the possible range of keys introduced by the salt. A minimum
-	// iteration count of 1000 is RECOMMENDED.
+	// Iterations is the PBKDF2 iteration count. A higher count raises the cost of
+	// a brute-force attack on the password; a minimum of 1000 is recommended.
 	Iterations int
-	// The salt size is the size of the salt in bytes. It is RECOMMENDED to
-	// use a salt size of 128 bits or more.
+	// SaltSize is the salt length in bytes. A salt of 128 bits or more is
+	// recommended.
 	SaltSize int
 
-	// CEK will be encrypted using the Secret.
+	// CEK is the content encryption key, encrypted under the wrap key derived from
+	// Secret.
 	CEK []byte
-	// Secret used to encrypt the CEK. The recipient will need to know this in order to decrypt the token.
+	// Secret is the password the wrap key is derived from. The recipient must know
+	// it to decrypt the token.
 	Secret string
 }
 
+// PBES2KeyEncKWConfig implements jwe.CEKManager: it derives a wrap key from a
+// password with PBES2 (PBKDF2) and wraps the content encryption key with AES Key
+// Wrap.
 type PBES2KeyEncKWConfig struct {
 	config PBES2KeyEncKWManagerConfig
 
@@ -62,12 +71,12 @@ type PBES2KeyEncKWConfig struct {
 	keySize int
 }
 
-// NewPBES2KeyEncKWManager creates a new jwe.CEKManager for a key derived using PBES2.
+// NewPBES2KeyEncKWManager creates a jwe.CEKManager that derives a wrap key from a
+// password with PBES2 and wraps the content encryption key with AES Key Wrap. The
+// preset selects the algorithm, hash, and key size; use one of the
+// PBES2KeyEncKWPreset values (for example PBES2A128KW).
 //
-// Use any of the PBES2KeyEncKWPreset constants to set the algorithm and key length.
-//   - PBES2A128KW: PBES2 using HMAC with SHA-256 and a key size of 128 bits
-//   - PBES2A192KW: PBES2 using HMAC with SHA-384 and a key size of 192 bits
-//   - PBES2A256KW: PBES2 using HMAC with SHA-512 and a key size of 256 bits
+// https://datatracker.ietf.org/doc/html/rfc7518#section-4.8
 func NewPBES2KeyEncKWManager(config *PBES2KeyEncKWManagerConfig, preset PBES2KeyEncKWPreset) *PBES2KeyEncKWConfig {
 	return &PBES2KeyEncKWConfig{
 		config:  *config,
@@ -82,7 +91,8 @@ func (manager *PBES2KeyEncKWConfig) SetHeader(_ context.Context, header *jwa.JWH
 		return nil, fmt.Errorf("(PBES2KeyEncKWConfig.SetHeader) %w: alg field already set", jwt.ErrConflictingHeader)
 	}
 
-	// Generate a random salt.
+	// A fresh salt per token widens the key space so the same password never
+	// derives the same wrap key twice. It travels in the header for the recipient.
 	salt := make([]byte, manager.config.SaltSize)
 
 	_, err := rand.Read(salt)
@@ -94,8 +104,6 @@ func (manager *PBES2KeyEncKWConfig) SetHeader(_ context.Context, header *jwa.JWH
 		P2S: base64.RawURLEncoding.EncodeToString(salt),
 		P2C: manager.config.Iterations,
 	}
-	// Might get changed by the actual encryption algorithm. This is an indication that key derivation was set
-	// using ECDH, so the algorithm can properly check for compatibility.
 	header.Alg = manager.alg
 
 	return header, nil
@@ -127,11 +135,16 @@ func (manager *PBES2KeyEncKWConfig) EncryptCEK(_ context.Context, header *jwa.JW
 	return wrapped, nil
 }
 
+// PBES2KeyEncKWDecoderConfig holds the password used to re-derive the wrap key and
+// decrypt the content encryption key.
 type PBES2KeyEncKWDecoderConfig struct {
-	// Secret used to decrypt the CEK.
+	// Secret is the password the wrap key is derived from; it must match the one
+	// used to encrypt the token.
 	Secret string
 }
 
+// PBES2KeyEncKWDecoder implements jwe.CEKDecoder: it re-derives the wrap key from
+// the password and unwraps the content encryption key with AES Key Wrap.
 type PBES2KeyEncKWDecoder struct {
 	config PBES2KeyEncKWDecoderConfig
 
@@ -140,12 +153,12 @@ type PBES2KeyEncKWDecoder struct {
 	keySize int
 }
 
-// NewPBES2KeyEncKWDecoder creates a new jwe.CEKDecoder for a key derived using PBES2.
+// NewPBES2KeyEncKWDecoder creates a jwe.CEKDecoder that re-derives the wrap key
+// from a password with PBES2 and unwraps the content encryption key with AES Key
+// Wrap. The preset must match the one used to encrypt the token; use one of the
+// PBES2KeyEncKWPreset values (for example PBES2A128KW).
 //
-// Use any of the PBES2KeyEncKWPreset constants to set the algorithm and key length.
-//   - PBES2A128KW: PBES2 using HMAC with SHA-256 and a key size of 128 bits
-//   - PBES2A192KW: PBES2 using HMAC with SHA-384 and a key size of 192 bits
-//   - PBES2A256KW: PBES2 using HMAC with SHA-512 and a key size of 256 bits
+// https://datatracker.ietf.org/doc/html/rfc7518#section-4.8
 func NewPBES2KeyEncKWDecoder(config *PBES2KeyEncKWDecoderConfig, preset PBES2KeyEncKWPreset) *PBES2KeyEncKWDecoder {
 	return &PBES2KeyEncKWDecoder{
 		config:  *config,

--- a/jwe/jwek/rsa_oaep_key_enc.go
+++ b/jwe/jwek/rsa_oaep_key_enc.go
@@ -13,6 +13,8 @@ import (
 	"github.com/a-novel-kit/jwt/jwa"
 )
 
+// RSAOAEPKeyEncPreset pairs a JWA algorithm identifier with the hash used by
+// RSAES-OAEP. Use one of the predefined presets rather than building one by hand.
 type RSAOAEPKeyEncPreset struct {
 	Alg  jwa.Alg
 	Hash hash.Hash
@@ -30,11 +32,15 @@ var (
 	}
 )
 
+// RSAOAEPKeyEncManagerConfig holds the content encryption key to protect and the
+// recipient RSA public key that encrypts it.
 type RSAOAEPKeyEncManagerConfig struct {
 	CEK    []byte
 	EncKey *rsa.PublicKey
 }
 
+// RSAOAEPKeyEncManager implements jwe.CEKManager, encrypting the content encryption
+// key to the recipient with RSAES-OAEP. See RFC 7518 section 4.3.
 type RSAOAEPKeyEncManager struct {
 	cek    []byte
 	encKey *rsa.PublicKey
@@ -43,11 +49,9 @@ type RSAOAEPKeyEncManager struct {
 	hash hash.Hash
 }
 
-// NewRSAOAEPKeyEncManager creates a new jwe.CEKManager for a key encrypted using RSAES-OAEP.
-//
-// Use any of the RSAOAEPKeyEncPreset to set the algorithm and hash function.
-//   - RSAOAEP: RSAES-OAEP using SHA-1 and MGF1 with SHA-1.
-//   - RSAOAEP256: RSAES-OAEP using SHA-256 and MGF1 with SHA-256.
+// NewRSAOAEPKeyEncManager creates a jwe.CEKManager that encrypts the content
+// encryption key to the recipient with RSAES-OAEP. The preset selects the
+// algorithm and hash; use RSAOAEP256 (RSAOAEP is deprecated, see its note).
 //
 // https://datatracker.ietf.org/doc/html/rfc7518#section-4.3
 func NewRSAOAEPKeyEncManager(
@@ -87,10 +91,14 @@ func (manager *RSAOAEPKeyEncManager) EncryptCEK(_ context.Context, _ *jwa.JWH, c
 	return encoded, nil
 }
 
+// RSAOAEPKeyEncDecoderConfig holds the recipient RSA private key used to decrypt
+// the content encryption key.
 type RSAOAEPKeyEncDecoderConfig struct {
 	EncKey *rsa.PrivateKey
 }
 
+// RSAOAEPKeyEncDecoder implements jwe.CEKDecoder, decrypting a content encryption
+// key that was encrypted with RSAES-OAEP. See RFC 7518 section 4.3.
 type RSAOAEPKeyEncDecoder struct {
 	encKey *rsa.PrivateKey
 
@@ -98,11 +106,9 @@ type RSAOAEPKeyEncDecoder struct {
 	hash hash.Hash
 }
 
-// NewRSAOAEPKeyEncDecoder creates a new jwe.CEKDecoder for a key encrypted using RSAES-OAEP.
-//
-// Use any of the RSAOAEPKeyEncPreset to set the algorithm and hash function.
-//   - RSAOAEP: RSAES-OAEP using SHA-1 and MGF1 with SHA-1.
-//   - RSAOAEP256: RSAES-OAEP using SHA-256 and MGF1 with SHA-256.
+// NewRSAOAEPKeyEncDecoder creates a jwe.CEKDecoder that decrypts an RSAES-OAEP
+// encrypted content encryption key. The preset must match the one used to encrypt
+// the token; use RSAOAEP256 (RSAOAEP is deprecated, see its note).
 //
 // https://datatracker.ietf.org/doc/html/rfc7518#section-4.3
 func NewRSAOAEPKeyEncDecoder(

--- a/jwe/key_manager.go
+++ b/jwe/key_manager.go
@@ -6,12 +6,23 @@ import (
 	"github.com/a-novel-kit/jwt/jwa"
 )
 
+// CEKManager supplies the content encryption key (CEK) to an encryption plugin and
+// decides how it reaches the recipient. Implementations vary by key-management scheme:
+// direct shared key, key wrapping, or key agreement.
 type CEKManager interface {
+	// SetHeader adds the header fields that tell the recipient how the CEK was managed.
 	SetHeader(ctx context.Context, header *jwa.JWH) (modifiedHeader *jwa.JWH, err error)
+	// ComputeCEK returns the key used to encrypt the token payload.
 	ComputeCEK(ctx context.Context, header *jwa.JWH) (cek []byte, err error)
+	// EncryptCEK returns the CEK in the form embedded in the token, empty when the
+	// recipient derives the key itself and nothing is transmitted.
 	EncryptCEK(ctx context.Context, header *jwa.JWH, cek []byte) (encrypted []byte, err error)
 }
 
+// CEKDecoder is the decryption counterpart of CEKManager: it recovers the content
+// encryption key from the header and the transmitted key material.
 type CEKDecoder interface {
+	// ComputeCEK returns the key used to decrypt the payload, given the encrypted key
+	// carried in the token (empty when none was transmitted).
 	ComputeCEK(ctx context.Context, header *jwa.JWH, encKey []byte) (cek []byte, err error)
 }

--- a/jwk/aes.go
+++ b/jwk/aes.go
@@ -12,6 +12,8 @@ import (
 	"github.com/a-novel-kit/jwt/jwk/serializers"
 )
 
+// An AESPreset describes how to generate or match an AES JSON Web Key: the algorithm it is bound
+// to, the key operations it permits, and its key size in bytes.
 type AESPreset struct {
 	Alg     jwa.Alg
 	KeyOps  jwa.KeyOps
@@ -126,24 +128,10 @@ var (
 
 // GenerateAES generates a new secret key for AES encryption algorithms.
 //
-// You can either retrieve the secret key directly (using res.Key()), or marshal the result into a JSON Web Key,
-// using json.Marshal.
+// Retrieve the raw key with res.Key(), or marshal the result into a JSON Web Key with json.Marshal.
 //
-// Available presets for CEK keys are:
-//   - A128CBC
-//   - A192CBC
-//   - A256CBC
-//   - A128GCM
-//   - A192GCM
-//   - A256GCM
-//
-// Available presets for KEK keys are:
-//   - A128KW
-//   - A192KW
-//   - A256KW
-//   - A128GCMKW
-//   - A192GCMKW
-//   - A256GCMKW
+// Pass one of the package's AES presets: the content-encryption presets, such as [A128GCM],
+// produce a CEK, and the key-wrapping presets, such as [A128KW], produce a KEK.
 func GenerateAES(preset AESPreset) (*Key[[]byte], error) {
 	key, err := generators.NewOct(preset.KeySize)
 	if err != nil {
@@ -173,25 +161,10 @@ func GenerateAES(preset AESPreset) (*Key[[]byte], error) {
 	return &Key[[]byte]{jsonKey, key}, nil
 }
 
-// ConsumeAES consumes a JSON Web Key and returns the secret key for AES encryption algorithms.
+// ConsumeAES parses a JSON Web Key into the secret key for an AES algorithm.
 //
-// If the JSON Web Key does not represent the AES key described by the preset, ErrJWKMismatch is returned.
-//
-// Available presets for CEK keys are:
-//   - A128CBC
-//   - A192CBC
-//   - A256CBC
-//   - A128GCM
-//   - A192GCM
-//   - A256GCM
-//
-// Available presets for KEK keys are:
-//   - A128KW
-//   - A192KW
-//   - A256KW
-//   - A128GCMKW
-//   - A192GCMKW
-//   - A256GCMKW
+// It returns ErrJWKMismatch when the key does not match the preset. Pass the same preset used to
+// generate the key; see [GenerateAES] for the available presets.
 func ConsumeAES(source *jwa.JWK, preset AESPreset) (*Key[[]byte], error) {
 	if !source.MatchPreset(jwa.JWKCommon{
 		KTY:    jwa.KTYOct,
@@ -217,6 +190,7 @@ func ConsumeAES(source *jwa.JWK, preset AESPreset) (*Key[[]byte], error) {
 	return NewKey[[]byte](source, decoded), nil
 }
 
+// NewAESSource returns a key source that parses the AES keys matching preset.
 func NewAESSource(config SourceConfig, preset AESPreset) *Source[[]byte] {
 	parser := func(_ context.Context, jwk *jwa.JWK) (*Key[[]byte], error) {
 		return ConsumeAES(jwk, preset)

--- a/jwk/common.go
+++ b/jwk/common.go
@@ -1,3 +1,9 @@
+// Package jwk generates and consumes JSON Web Keys for the jwt toolkit.
+//
+// Each supported algorithm family exposes a matching pair of helpers: a Generate function that
+// mints fresh key material and returns it as a typed [Key], and a Consume function that parses an
+// external JSON Web Key back into that typed key. A [Source] wraps a fetcher and caches parsed
+// keys so a caller can look them up by ID when verifying tokens.
 package jwk
 
 import (
@@ -6,18 +12,24 @@ import (
 	"github.com/a-novel-kit/jwt/jwa"
 )
 
+// ErrJWKMismatch is returned when a JSON Web Key does not match the preset it is parsed against —
+// a different algorithm, key type, use, or set of key operations.
 var ErrJWKMismatch = errors.New("jwk and key mismatch")
 
+// A Key pairs a JSON Web Key with its decoded native representation of type K, such as an
+// *rsa.PrivateKey or a raw byte slice. The embedded [jwa.JWK] carries the serialized form.
 type Key[K any] struct {
 	*jwa.JWK
 
 	parsed K
 }
 
+// Key returns the decoded native key.
 func (key *Key[K]) Key() K {
 	return key.parsed
 }
 
+// NewKey pairs an already-decoded key with its JSON Web Key form.
 func NewKey[K any](jwk *jwa.JWK, parsed K) *Key[K] {
 	return &Key[K]{jwk, parsed}
 }

--- a/jwk/ecdh.go
+++ b/jwk/ecdh.go
@@ -13,10 +13,9 @@ import (
 	"github.com/a-novel-kit/jwt/jwk/serializers"
 )
 
-// GenerateECDH generates a new ECDH key pair.
+// GenerateECDH generates a new ECDH key pair on the X25519 curve.
 //
-// You can either retrieve the secret key directly (using res.Key()), or marshal the result into a JSON Web Key,
-// using json.Marshal.
+// Retrieve a raw key with res.Key(), or marshal either result into a JSON Web Key with json.Marshal.
 func GenerateECDH() (*Key[*ecdh.PrivateKey], *Key[*ecdh.PublicKey], error) {
 	privateKey, err := ecdh.X25519().GenerateKey(rand.Reader)
 	if err != nil {
@@ -74,11 +73,10 @@ func GenerateECDH() (*Key[*ecdh.PrivateKey], *Key[*ecdh.PublicKey], error) {
 	return &Key[*ecdh.PrivateKey]{privateJSONKey, privateKey}, &Key[*ecdh.PublicKey]{publicJSONKey, publicKey}, nil
 }
 
-// ConsumeECDH consumes a JSON Web Key and returns the secret key for ECDH encryption algorithms.
+// ConsumeECDH parses a JSON Web Key into an ECDH key-agreement key pair. When the key holds only a
+// public key, the returned private key is nil.
 //
-// If the JSON Web Key does not represent the ECDH key, ErrJWKMismatch is returned.
-//
-// If the key represents a public key only, the private key will be nil.
+// It returns ErrJWKMismatch when the key does not represent an ECDH key.
 func ConsumeECDH(source *jwa.JWK) (*Key[*ecdh.PrivateKey], *Key[*ecdh.PublicKey], error) {
 	if !source.MatchPreset(jwa.JWKCommon{
 		KTY:    jwa.KTYOKP,
@@ -117,6 +115,8 @@ func ConsumeECDH(source *jwa.JWK) (*Key[*ecdh.PrivateKey], *Key[*ecdh.PublicKey]
 	return privateKey, publicKey, nil
 }
 
+// NewECDHPublicSource returns a key source that yields ECDH public keys and rejects any source
+// that exposes private key material.
 func NewECDHPublicSource(config SourceConfig) *Source[*ecdh.PublicKey] {
 	parser := func(_ context.Context, jwk *jwa.JWK) (*Key[*ecdh.PublicKey], error) {
 		privateKey, publicKey, err := ConsumeECDH(jwk)
@@ -130,6 +130,7 @@ func NewECDHPublicSource(config SourceConfig) *Source[*ecdh.PublicKey] {
 	return NewGenericSource[*ecdh.PublicKey](config, parser)
 }
 
+// NewECDHPrivateSource returns a key source that yields ECDH private keys.
 func NewECDHPrivateSource(config SourceConfig) *Source[*ecdh.PrivateKey] {
 	parser := func(_ context.Context, jwk *jwa.JWK) (*Key[*ecdh.PrivateKey], error) {
 		privateKey, _, err := ConsumeECDH(jwk)

--- a/jwk/ecdsa.go
+++ b/jwk/ecdsa.go
@@ -14,11 +14,14 @@ import (
 	"github.com/a-novel-kit/jwt/jwk/serializers"
 )
 
+// An ECDSAPreset describes how to generate or match an ECDSA JSON Web Key: the algorithm it is
+// bound to and the elliptic curve its keys live on.
 type ECDSAPreset struct {
 	Alg   jwa.Alg
 	Curve elliptic.Curve
 }
 
+// Signature algorithms.
 var (
 	ES256 = ECDSAPreset{
 		Alg:   jwa.ES256,
@@ -36,13 +39,9 @@ var (
 
 // GenerateECDSA generates a new ECDSA key pair.
 //
-// You can either retrieve the secret key directly (using res.Key()), or marshal the result into a JSON Web Key,
-// using json.Marshal.
+// Retrieve a raw key with res.Key(), or marshal either result into a JSON Web Key with json.Marshal.
 //
-// Available presets are:
-//   - ES256
-//   - ES384
-//   - ES512
+// Pass one of the ECDSA presets, such as [ES256].
 func GenerateECDSA(preset ECDSAPreset) (*Key[*ecdsa.PrivateKey], *Key[*ecdsa.PublicKey], error) {
 	privateKey, err := ecdsa.GenerateKey(preset.Curve, rand.Reader)
 	if err != nil {
@@ -100,16 +99,11 @@ func GenerateECDSA(preset ECDSAPreset) (*Key[*ecdsa.PrivateKey], *Key[*ecdsa.Pub
 	return &Key[*ecdsa.PrivateKey]{privateJSONKey, privateKey}, &Key[*ecdsa.PublicKey]{publicJSONKey, publicKey}, nil
 }
 
-// ConsumeECDSA consumes a JSON Web Key and returns the secret key for ECDSA encryption algorithms.
+// ConsumeECDSA parses a JSON Web Key into an ECDSA signature key pair. When the key holds only a
+// public key, the returned private key is nil.
 //
-// If the JSON Web Key does not represent the ECDSA key described by the preset, ErrJWKMismatch is returned.
-//
-// If the key represents a public key only, the private key will be nil.
-//
-// Available presets are:
-//   - ES256
-//   - ES384
-//   - ES512
+// It returns ErrJWKMismatch when the key does not match the preset. Pass the same preset used to
+// generate the key; see [GenerateECDSA] for the available presets.
 func ConsumeECDSA(source *jwa.JWK, preset ECDSAPreset) (*Key[*ecdsa.PrivateKey], *Key[*ecdsa.PublicKey], error) {
 	matchPrivate := source.MatchPreset(jwa.JWKCommon{
 		KTY:    jwa.KTYEC,
@@ -156,6 +150,8 @@ func ConsumeECDSA(source *jwa.JWK, preset ECDSAPreset) (*Key[*ecdsa.PrivateKey],
 	return privateKey, publicKey, nil
 }
 
+// NewECDSAPublicSource returns a key source that yields ECDSA public keys and rejects any source
+// that exposes private key material.
 func NewECDSAPublicSource(config SourceConfig, preset ECDSAPreset) *Source[*ecdsa.PublicKey] {
 	parser := func(_ context.Context, jwk *jwa.JWK) (*Key[*ecdsa.PublicKey], error) {
 		privateKey, publicKey, err := ConsumeECDSA(jwk, preset)
@@ -169,6 +165,7 @@ func NewECDSAPublicSource(config SourceConfig, preset ECDSAPreset) *Source[*ecds
 	return NewGenericSource[*ecdsa.PublicKey](config, parser)
 }
 
+// NewECDSAPrivateSource returns a key source that yields ECDSA private keys.
 func NewECDSAPrivateSource(config SourceConfig, preset ECDSAPreset) *Source[*ecdsa.PrivateKey] {
 	parser := func(_ context.Context, jwk *jwa.JWK) (*Key[*ecdsa.PrivateKey], error) {
 		privateKey, _, err := ConsumeECDSA(jwk, preset)

--- a/jwk/ed25519.go
+++ b/jwk/ed25519.go
@@ -13,10 +13,9 @@ import (
 	"github.com/a-novel-kit/jwt/jwk/serializers"
 )
 
-// GenerateED25519 generates a new ED25519 key pair.
+// GenerateED25519 generates a new Ed25519 key pair.
 //
-// You can either retrieve the secret key directly (using res.Key()), or marshal the result into a JSON Web Key,
-// using json.Marshal.
+// Retrieve a raw key with res.Key(), or marshal either result into a JSON Web Key with json.Marshal.
 func GenerateED25519() (*Key[ed25519.PrivateKey], *Key[ed25519.PublicKey], error) {
 	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
@@ -67,11 +66,10 @@ func GenerateED25519() (*Key[ed25519.PrivateKey], *Key[ed25519.PublicKey], error
 		nil
 }
 
-// ConsumeED25519 consumes a JSON Web Key and returns the secret key for ED25519 signature algorithms.
+// ConsumeED25519 parses a JSON Web Key into an Ed25519 signature key pair. When the key holds only
+// a public key, the returned private key is nil.
 //
-// If the JSON Web Key does not represent the ED25519 key, ErrJWKMismatch is returned.
-//
-// If the key represents a public key only, the private key will be nil.
+// It returns ErrJWKMismatch when the key does not represent an Ed25519 key.
 func ConsumeED25519(source *jwa.JWK) (*Key[ed25519.PrivateKey], *Key[ed25519.PublicKey], error) {
 	matchPrivate := source.MatchPreset(jwa.JWKCommon{
 		KTY:    jwa.KTYOKP,
@@ -118,6 +116,8 @@ func ConsumeED25519(source *jwa.JWK) (*Key[ed25519.PrivateKey], *Key[ed25519.Pub
 	return privateKey, publicKey, nil
 }
 
+// NewED25519PublicSource returns a key source that yields Ed25519 public keys and rejects any
+// source that exposes private key material.
 func NewED25519PublicSource(config SourceConfig) *Source[ed25519.PublicKey] {
 	parser := func(_ context.Context, jwk *jwa.JWK) (*Key[ed25519.PublicKey], error) {
 		privateKey, publicKey, err := ConsumeED25519(jwk)
@@ -131,6 +131,7 @@ func NewED25519PublicSource(config SourceConfig) *Source[ed25519.PublicKey] {
 	return NewGenericSource[ed25519.PublicKey](config, parser)
 }
 
+// NewED25519PrivateSource returns a key source that yields Ed25519 private keys.
 func NewED25519PrivateSource(config SourceConfig) *Source[ed25519.PrivateKey] {
 	parser := func(_ context.Context, jwk *jwa.JWK) (*Key[ed25519.PrivateKey], error) {
 		privateKey, _, err := ConsumeED25519(jwk)

--- a/jwk/generators/oct.go
+++ b/jwk/generators/oct.go
@@ -1,3 +1,4 @@
+// Package generators produces the raw key material behind JSON Web Keys.
 package generators
 
 import (

--- a/jwk/hmac.go
+++ b/jwk/hmac.go
@@ -12,6 +12,8 @@ import (
 	"github.com/a-novel-kit/jwt/jwk/serializers"
 )
 
+// An HMACPreset describes how to generate or match an HMAC JSON Web Key: the algorithm it is bound
+// to and its key size in bytes.
 type HMACPreset struct {
 	Alg     jwa.Alg
 	KeySize int
@@ -40,13 +42,9 @@ var (
 
 // GenerateHMAC generates a new secret key for HMAC signature algorithms.
 //
-// You can either retrieve the secret key directly (using res.Key()), or marshal the result into a JSON Web Key,
-// using json.Marshal.
+// Retrieve the raw key with res.Key(), or marshal the result into a JSON Web Key with json.Marshal.
 //
-// Available presets are:
-//   - HS256
-//   - HS384
-//   - HS512
+// Pass one of the HMAC presets, such as [HS256].
 func GenerateHMAC(preset HMACPreset) (*Key[[]byte], error) {
 	key, err := generators.NewOct(preset.KeySize)
 	if err != nil {
@@ -76,14 +74,10 @@ func GenerateHMAC(preset HMACPreset) (*Key[[]byte], error) {
 	return &Key[[]byte]{jsonKey, key}, nil
 }
 
-// ConsumeHMAC consumes a JSON Web Key and returns the secret key for HMAC signature algorithms.
+// ConsumeHMAC parses a JSON Web Key into the secret key for an HMAC algorithm.
 //
-// If the JSON Web Key does not represent the HMAC key described by the preset, ErrJWKMismatch is returned.
-//
-// Available presets are:
-//   - HS256
-//   - HS384
-//   - HS512
+// It returns ErrJWKMismatch when the key does not match the preset. Pass the same preset used to
+// generate the key; see [GenerateHMAC] for the available presets.
 func ConsumeHMAC(source *jwa.JWK, preset HMACPreset) (*Key[[]byte], error) {
 	if !source.MatchPreset(jwa.JWKCommon{
 		KTY:    jwa.KTYOct,
@@ -109,6 +103,7 @@ func ConsumeHMAC(source *jwa.JWK, preset HMACPreset) (*Key[[]byte], error) {
 	return NewKey[[]byte](source, decoded), nil
 }
 
+// NewHMACSource returns a key source that parses the HMAC keys matching preset.
 func NewHMACSource(config SourceConfig, preset HMACPreset) *Source[[]byte] {
 	parser := func(_ context.Context, jwk *jwa.JWK) (*Key[[]byte], error) {
 		return ConsumeHMAC(jwk, preset)

--- a/jwk/rsa.go
+++ b/jwk/rsa.go
@@ -13,6 +13,9 @@ import (
 	"github.com/a-novel-kit/jwt/jwk/serializers"
 )
 
+// An RSAPreset describes how to generate or match an RSA JSON Web Key: the algorithm it is bound
+// to, whether the key is used for signatures or key management, the operations allowed on each
+// half of the pair, and the modulus size in bits.
 type RSAPreset struct {
 	Alg           jwa.Alg
 	Use           jwa.Use
@@ -71,7 +74,7 @@ var (
 		// The signature size (in bytes, before re-encoding as text) is the key size (in bit), divided by 8 and rounded up
 		// to the next integer.
 		//
-		// ⌈4096/8⌉=512 bytes.
+		// ⌈2048/8⌉=256 bytes.
 		//
 		// https://crypto.stackexchange.com/a/95882
 		KeySize: 2048,
@@ -124,20 +127,10 @@ var (
 
 // GenerateRSA generates a new RSA public/private key pair.
 //
-// You can either retrieve the secret key directly (using res.Key()), or marshal the result into a JSON Web Key,
-// using json.Marshal.
+// Retrieve a raw key with res.Key(), or marshal either result into a JSON Web Key with json.Marshal.
 //
-// Available presets for signature algorithms are:
-//   - RS256
-//   - RS384
-//   - RS512
-//   - PS256
-//   - PS384
-//   - PS512
-//
-// Available presets for key management algorithms are:
-//   - RSAOAEP
-//   - RSAOAEP256
+// Pass one of the RSA presets: the signature presets, such as [RS256], or the key-management
+// presets, such as [RSAOAEP].
 func GenerateRSA(preset RSAPreset) (*Key[*rsa.PrivateKey], *Key[*rsa.PublicKey], error) {
 	privateKey, err := rsa.GenerateKey(rand.Reader, preset.KeySize)
 	if err != nil {
@@ -188,23 +181,11 @@ func GenerateRSA(preset RSAPreset) (*Key[*rsa.PrivateKey], *Key[*rsa.PublicKey],
 	return &Key[*rsa.PrivateKey]{privateJSONKey, privateKey}, &Key[*rsa.PublicKey]{publicJSONKey, publicKey}, nil
 }
 
-// ConsumeRSA consumes a JSON Web Key and returns the secret key for RSA signature and encryption algorithms.
+// ConsumeRSA parses a JSON Web Key into an RSA key pair for signature or key-management
+// algorithms. When the key holds only a public key, the returned private key is nil.
 //
-// If the JSON Web Key does not represent the RSA key described by the preset, ErrJWKMismatch is returned.
-//
-// If the key represents a public key only, the private key will be nil.
-//
-// Available presets for signature algorithms are:
-//   - RS256
-//   - RS384
-//   - RS512
-//   - PS256
-//   - PS384
-//   - PS512
-//
-// Available presets for key management algorithms are:
-//   - RSAOAEP
-//   - RSAOAEP256
+// It returns ErrJWKMismatch when the key does not match the preset. Pass the same preset used to
+// generate the key; see [GenerateRSA] for the available presets.
 func ConsumeRSA(source *jwa.JWK, preset RSAPreset) (*Key[*rsa.PrivateKey], *Key[*rsa.PublicKey], error) {
 	matchPrivate := source.MatchPreset(jwa.JWKCommon{
 		KTY:    jwa.KTYRSA,
@@ -251,6 +232,8 @@ func ConsumeRSA(source *jwa.JWK, preset RSAPreset) (*Key[*rsa.PrivateKey], *Key[
 	return privateKey, publicKey, nil
 }
 
+// NewRSAPublicSource returns a key source that yields RSA public keys and rejects any source that
+// exposes private key material.
 func NewRSAPublicSource(config SourceConfig, preset RSAPreset) *Source[*rsa.PublicKey] {
 	parser := func(_ context.Context, jwk *jwa.JWK) (*Key[*rsa.PublicKey], error) {
 		privateKey, publicKey, err := ConsumeRSA(jwk, preset)
@@ -264,6 +247,7 @@ func NewRSAPublicSource(config SourceConfig, preset RSAPreset) *Source[*rsa.Publ
 	return NewGenericSource[*rsa.PublicKey](config, parser)
 }
 
+// NewRSAPrivateSource returns a key source that yields RSA private keys.
 func NewRSAPrivateSource(config SourceConfig, preset RSAPreset) *Source[*rsa.PrivateKey] {
 	parser := func(_ context.Context, jwk *jwa.JWK) (*Key[*rsa.PrivateKey], error) {
 		privateKey, _, err := ConsumeRSA(jwk, preset)

--- a/jwk/serializers/common.go
+++ b/jwk/serializers/common.go
@@ -2,4 +2,5 @@ package serializers
 
 import "errors"
 
+// ErrUnsupportedCurve is returned by a decoder when the payload names a curve this library cannot handle.
 var ErrUnsupportedCurve = errors.New("unsupported curve")

--- a/jwk/serializers/ecdh.go
+++ b/jwk/serializers/ecdh.go
@@ -8,24 +8,17 @@ import (
 	"github.com/a-novel-kit/jwt/jwa"
 )
 
-// ECDHPayload wraps a ECDH-ES key in a JWKCommon format.
+// An ECDHPayload wraps an ECDH-ES key in a JWKCommon format.
 type ECDHPayload struct {
-	// Crv (curve) parameter.
-	//
-	// Since the proposal of adding 448 curve variants to the standard library was declined due to complexity and
-	// low benefits, it is currently not supported by this library. Thus, using a curve value other than "X25519"
-	// will throw an error.
+	// Crv is the JWK curve identifier. Only "X25519" is supported: the standard library does not implement the
+	// X448 variant, so any other value makes DecodeECDH return an error. Plug in your own decoder if you need X448.
 	//
 	// https://github.com/golang/go/issues/29390
-	//
-	// You may still use your own decoded that supports x448.
 	Crv string `json:"crv"`
-	// X coordinate parameter.
+	// X is the base64url-encoded public key.
 	X string `json:"x"`
 
-	// PRIVATE KEY.
-
-	// D (ECC private key) parameter.
+	// D is the base64url-encoded private key, set only for private keys.
 	D string `json:"d,omitempty"`
 }
 

--- a/jwk/serializers/ecdsa.go
+++ b/jwk/serializers/ecdsa.go
@@ -34,7 +34,8 @@ type ECPayload struct {
 // ---------------------------------------------------------------------------------------------------------------------
 // Reimplemented from crypto/ecdsa internals, which the standard library does not export.
 
-// pointFromAffine encodes affine coordinates into the uncompressed point bytes ecdsa.ParseUncompressedPublicKey expects.
+// pointFromAffine encodes affine coordinates into the uncompressed point bytes
+// that ecdsa.ParseUncompressedPublicKey expects.
 func pointFromAffine(curve elliptic.Curve, x, y *big.Int) ([]byte, error) {
 	bitSize := curve.Params().BitSize
 	// Reject values that would not get correctly encoded.

--- a/jwk/serializers/ecdsa.go
+++ b/jwk/serializers/ecdsa.go
@@ -9,74 +9,32 @@ import (
 	"math/big"
 )
 
-// ECPayload wraps a ECDSA key in a JWKCommon format.
+// An ECPayload wraps an ECDSA key in a JWKCommon format.
 type ECPayload struct {
-	// Crv (curve) parameter.
+	// Crv is the case-sensitive JWK name of the elliptic curve the key belongs to. DecodeEC accepts the curves
+	// listed in its switch; any other value returns ErrUnsupportedCurve.
 	//
 	// https://datatracker.ietf.org/doc/html/rfc7518#section-6.2.1.1
-	//
-	// The "crv" (curve) parameter identifies the cryptographic curve used
-	// with the key. Curve values from [DSS] used by this specification
-	// are:
-	//
-	// o "P-256"
-	// o "P-384"
-	// o "P-521"
-	//
-	// These values are registered in the IANA "JSON Web CEK Elliptic Curve"
-	// registry defined in Section 7.6. Additional "crv" values can be
-	// registered by other specifications. Specifications registering
-	// additional curves must define what parameters are used to represent
-	// keys for the curves registered. The "crv" value is a case-sensitive
-	// string.
-	//
-	// SEC1 [SEC1] point compression is not supported for any of these three
-	// curves.
 	Crv string `json:"crv"`
-	// X coordinate parameter.
+	// X is the base64url-encoded x coordinate of the curve point.
 	//
 	// https://datatracker.ietf.org/doc/html/rfc7518#section-6.2.1.2
-	//
-	// The "x" (x coordinate) parameter contains the x coordinate for the
-	// Elliptic Curve point. It is represented as the base64url encoding of
-	// the octet string representation of the coordinate, as defined in
-	// Section 2.3.5 of SEC1 [SEC1]. The length of this octet string MUST
-	// be the full size of a coordinate for the curve specified in the "crv"
-	// parameter. For example, if the value of "crv" is "P-521", the octet
-	// string must be 66 octets long.
 	X string `json:"x"`
-	// Y coordinate parameter.
+	// Y is the base64url-encoded y coordinate of the curve point.
 	//
 	// https://datatracker.ietf.org/doc/html/rfc7518#section-6.2.1.3
-	//
-	// The "y" (y coordinate) parameter contains the y coordinate for the
-	// Elliptic Curve point. It is represented as the base64url encoding of
-	// the octet string representation of the coordinate, as defined in
-	// Section 2.3.5 of SEC1 [SEC1]. The length of this octet string MUST
-	// be the full size of a coordinate for the curve specified in the "crv"
-	// parameter. For example, if the value of "crv" is "P-521", the octet
-	// string must be 66 octets long.
 	Y string `json:"y"`
 
-	// PRIVATE KEY.
-
-	// D (ECC private key) parameter.
+	// D is the base64url-encoded private key value, set only for private keys.
 	//
 	// https://datatracker.ietf.org/doc/html/rfc7518#section-6.2.2.1
-	//
-	// The "d" (ECC private key) parameter contains the Elliptic Curve
-	// private key value. It is represented as the base64url encoding of
-	// the octet string representation of the private key value, as defined
-	// in Section 2.3.7 of SEC1 [SEC1]. The length of this octet string
-	// MUST be ceiling(log-base-2(n)/8) octets (where n is the order of the
-	// curve).
 	D string `json:"d,omitempty"`
 }
 
 // ---------------------------------------------------------------------------------------------------------------------
-// Imported from go internal package.
+// Reimplemented from crypto/ecdsa internals, which the standard library does not export.
 
-// pointFromAffine is used to convert the PublicKey to a nistec SetBytes input.
+// pointFromAffine encodes affine coordinates into the uncompressed point bytes ecdsa.ParseUncompressedPublicKey expects.
 func pointFromAffine(curve elliptic.Curve, x, y *big.Int) ([]byte, error) {
 	bitSize := curve.Params().BitSize
 	// Reject values that would not get correctly encoded.
@@ -97,7 +55,7 @@ func pointFromAffine(curve elliptic.Curve, x, y *big.Int) ([]byte, error) {
 	return buf, nil
 }
 
-// pointToAffine is used to convert a nistec Bytes encoding to a PublicKey.
+// pointToAffine splits uncompressed point bytes back into their affine x and y coordinates.
 //
 //nolint:nonamedreturns
 func pointToAffine(curve elliptic.Curve, p []byte) (x, y *big.Int, err error) {
@@ -131,7 +89,7 @@ func parsePublicKeyParams(key *ecdsa.PublicKey) (*big.Int, *big.Int, elliptic.Cu
 	return x, y, crv, nil
 }
 
-// DecodeEC takes the representation of a ECPayload and computes the key it contains.
+// DecodeEC reconstructs the ECDSA key carried by an ECPayload, returning the private key when the payload holds one.
 func DecodeEC(src *ECPayload) (*ecdsa.PrivateKey, *ecdsa.PublicKey, error) {
 	var curve elliptic.Curve
 
@@ -183,7 +141,7 @@ func DecodeEC(src *ECPayload) (*ecdsa.PrivateKey, *ecdsa.PublicKey, error) {
 	return keyPriv, keyPub, nil
 }
 
-// EncodeEC takes a key and create a ECPayload representation of it.
+// EncodeEC builds the ECPayload representation of an ECDSA public or private key.
 func EncodeEC[Key *ecdsa.PublicKey | *ecdsa.PrivateKey](key Key) (*ECPayload, error) {
 	payload := new(ECPayload)
 

--- a/jwk/serializers/ed25519.go
+++ b/jwk/serializers/ed25519.go
@@ -9,27 +9,21 @@ import (
 	"github.com/a-novel-kit/jwt/jwa"
 )
 
-// EDPayload wraps a EDDSA key in a JWKCommon format.
+// An EDPayload wraps an EdDSA key in a JWKCommon format.
 type EDPayload struct {
-	// Crv (curve) parameter.
-	//
-	// Since the proposal of adding 448 curve variants to the standard library was declined due to complexity and
-	// low benefits, it is currently not supported by this library. Thus, using a curve value other than "Ed25519"
-	// will throw an error.
+	// Crv is the JWK curve identifier. Only "Ed25519" is supported: the standard library does not implement the
+	// Ed448 variant, so any other value makes DecodeED return an error. Plug in your own decoder if you need Ed448.
 	//
 	// https://github.com/golang/go/issues/29390
-	//
-	// You may still use your own decoded that supports x448.
 	Crv string `json:"crv"`
-	// X coordinate parameter.
+	// X is the base64url-encoded public key.
 	X string `json:"x"`
 
-	// PRIVATE KEY.
-
-	// D (ECC private key) parameter.
+	// D is the base64url-encoded private key, set only for private keys.
 	D string `json:"d,omitempty"`
 }
 
+// ErrInvalidEDKey is returned when a decoded EdDSA key does not have the size Ed25519 requires.
 var ErrInvalidEDKey = errors.New("invalid EdDSA key")
 
 // DecodeED decodes the EdDSA key from a JWKCommon format.

--- a/jwk/serializers/oct.go
+++ b/jwk/serializers/oct.go
@@ -5,19 +5,15 @@ import (
 	"fmt"
 )
 
-// OctPayload wraps a symmetric key in a JWKCommon format.
+// An OctPayload wraps a symmetric key in a JWKCommon format.
 type OctPayload struct {
-	// K (CEK Value) Parameter.
+	// K is the base64url-encoded symmetric key value.
 	//
 	// https://datatracker.ietf.org/doc/html/rfc7518#section-6.4.1
-	//
-	// The "k" (key value) parameter contains the value of the symmetric (or
-	// other single-valued) key. It is represented as the base64url
-	// encoding of the octet sequence containing the key value.
 	K string `json:"k"`
 }
 
-// DecodeOct takes the representation of a OctPayload and computes the key it contains.
+// DecodeOct returns the raw key bytes carried by an OctPayload.
 func DecodeOct(src *OctPayload) ([]byte, error) {
 	key, err := base64.RawURLEncoding.DecodeString(src.K)
 	if err != nil {
@@ -27,7 +23,7 @@ func DecodeOct(src *OctPayload) ([]byte, error) {
 	return key, nil
 }
 
-// EncodeOct takes a key and create a OctPayload representation of it.
+// EncodeOct wraps a raw symmetric key as an OctPayload.
 func EncodeOct(key []byte) *OctPayload {
 	return &OctPayload{
 		K: base64.RawURLEncoding.EncodeToString(key),

--- a/jwk/serializers/rsa.go
+++ b/jwk/serializers/rsa.go
@@ -7,132 +7,66 @@ import (
 	"math/big"
 )
 
+// An RSAOtherPrime describes a third or later prime factor of an RSA private key built from more than two primes,
+// together with the CRT values derived from it. Values are Base64urlUInt-encoded.
+//
+// https://datatracker.ietf.org/doc/html/rfc7518#section-6.3.2.7
 type RSAOtherPrime struct {
-	// R prime factor.
-	//
-	// https://datatracker.ietf.org/doc/html/rfc7518#section-6.3.2.7.1
-	//
-	// The "r" (prime factor) parameter within an "oth" array member
-	// represents the value of a subsequent prime factor. It is represented
-	// as a Base64urlUInt-encoded value.
+	// R is the prime factor.
 	R string `json:"r"`
-	// D factor CRT exponent.
-	//
-	// https://datatracker.ietf.org/doc/html/rfc7518#section-6.3.2.7.2
-	//
-	// The "d" (factor CRT exponent) parameter within an "oth" array member
-	// represents the CRT exponent of the corresponding prime factor. It is
-	// represented as a Base64urlUInt-encoded value.
+	// D is the factor's CRT exponent.
 	D string `json:"d"`
-	// T factor CRT coefficient.
-	//
-	// https://datatracker.ietf.org/doc/html/rfc7518#section-6.3.2.7.3
-	//
-	// The "t" (factor CRT coefficient) parameter within an "oth" array
-	// member represents the CRT coefficient of the corresponding prime
-	// factor. It is represented as a Base64urlUInt-encoded value.
+	// T is the factor's CRT coefficient.
 	T string `json:"t"`
 }
 
-// RSAPayload wraps a RSA key in a JWKCommon format.
+// An RSAPayload wraps an RSA key in a JWKCommon format. Every numeric field is Base64urlUInt-encoded, following
+// RFC 7518 §6.3.
 type RSAPayload struct {
-	// N modulus of the key.
+	// N is the key modulus.
 	//
 	// https://datatracker.ietf.org/doc/html/rfc7518#section-6.3.1.1
-	//
-	// The "n" (modulus) parameter contains the modulus value for the RSA
-	// public key. It is represented as a Base64urlUInt-encoded value.
-	//
-	// Note that implementers have found that some cryptographic libraries
-	// prefix an extra zero-valued octet to the modulus representations they
-	// return, for instance, returning 257 octets for a 2048-bit key, rather
-	// than 256. Implementations using such libraries will need to take
-	// care to omit the extra octet from the base64url-encoded
-	// representation.
 	N string `json:"n"`
-	// E exponent of the key.
+	// E is the public exponent. For example, 65537 encodes as "AQAB".
 	//
 	// https://datatracker.ietf.org/doc/html/rfc7518#section-6.3.1.2
-	//
-	// The "e" (exponent) parameter contains the exponent value for the RSA
-	// public key. It is represented as a Base64urlUInt-encoded value.
-	//
-	// For instance, when representing the value 65537, the octet sequence
-	// to be base64url-encoded MUST consist of the three octets [1, 0, 1];
-	// the resulting representation for this value is "AQAB".
 	E string `json:"e"`
 
-	// PRIVATE KEY.
-
-	// D private exponent of the key.
+	// D is the private exponent, set only for private keys.
 	//
 	// https://datatracker.ietf.org/doc/html/rfc7518#section-6.3.2.1
-	//
-	// The "d" (private exponent) parameter contains the private exponent
-	// value for the RSA private key. It is represented as a Base64urlUInt-
-	// encoded value.
 	D string `json:"d,omitempty"`
 
-	// P first prime factor of the key.
+	// P is the first prime factor.
 	//
 	// https://datatracker.ietf.org/doc/html/rfc7518#section-6.3.2.2
-	//
-	// The "p" (first prime factor) parameter contains the first prime
-	// factor. It is represented as a Base64urlUInt-encoded value.
 	P string `json:"p,omitempty"`
-	// Q second prime factor of the key.
+	// Q is the second prime factor.
 	//
 	// https://datatracker.ietf.org/doc/html/rfc7518#section-6.3.2.3
-	//
-	// The "q" (second prime factor) parameter contains the second prime
-	// factor. It is represented as a Base64urlUInt-encoded value.
 	Q string `json:"q,omitempty"`
 
-	// DP first factor CRT exponent.
+	// DP is the first factor CRT exponent.
 	//
-	//https://datatracker.ietf.org/doc/html/rfc7518#section-6.3.2.4
-	//
-	// The "dp" (first factor CRT exponent) parameter contains the Chinese
-	// Remainder Theorem (CRT) exponent of the first factor. It is
-	// represented as a Base64urlUInt-encoded value.
+	// https://datatracker.ietf.org/doc/html/rfc7518#section-6.3.2.4
 	DP string `json:"dp,omitempty"`
-	// DQ second factor CRT exponent.
+	// DQ is the second factor CRT exponent.
 	//
 	// https://datatracker.ietf.org/doc/html/rfc7518#section-6.3.2.5
-	//
-	// The "dq" (second factor CRT exponent) parameter contains the CRT
-	// exponent of the second factor. It is represented as a Base64urlUInt-
-	// encoded value.
 	DQ string `json:"dq,omitempty"`
-	// QI first CRT coefficient.
+	// QI is the first CRT coefficient.
 	//
 	// https://datatracker.ietf.org/doc/html/rfc7518#section-6.3.2.6
-	//
-	// The "qi" (first CRT coefficient) parameter contains the CRT
-	// coefficient of the second factor. It is represented as a
-	// Base64urlUInt-encoded value.
 	QI string `json:"qi,omitempty"`
 
-	// Oth other primes info.
+	// Oth carries the remaining prime factors when the key was built from more than two primes; it is omitted for
+	// the usual two-prime key.
 	//
 	// https://datatracker.ietf.org/doc/html/rfc7518#section-6.3.2.7
-	//
-	// The "oth" (other primes info) parameter contains an array of
-	// information about any third and subsequent primes, should they exist.
-	// When only two primes have been used (the normal case), this parameter
-	// MUST be omitted. When three or more primes have been used, the
-	// number of array elements MUST be the number of primes used minus two.
-	// For more information on this case, see the description of the
-	// OtherPrimeInfo parameters in Appendix A.1.2 of RFC 3447 [RFC3447],
-	// upon which the following parameters are modeled. If the consumer of
-	// a JWKCommon does not support private keys with more than two primes and it
-	// encounters a private key that includes the "oth" parameter, then it
-	// MUST NOT use the key. Each array element MUST be an object with the
-	// following members.
 	Oth []RSAOtherPrime `json:"oth,omitempty"`
 }
 
-// DecodeRSA takes the representation of a RSAPayload and computes the key it contains.
+// DecodeRSA reconstructs the RSA key carried by an RSAPayload, returning the private key when the payload holds one.
 func DecodeRSA(src *RSAPayload) (*rsa.PrivateKey, *rsa.PublicKey, error) {
 	n, err := base64.RawURLEncoding.DecodeString(src.N)
 	if err != nil {
@@ -240,7 +174,7 @@ func DecodeRSA(src *RSAPayload) (*rsa.PrivateKey, *rsa.PublicKey, error) {
 	return key, keyPub, nil
 }
 
-// EncodeRSA takes a key and create a RSAPayload representation of it.
+// EncodeRSA builds the RSAPayload representation of an RSA public or private key.
 func EncodeRSA[Key *rsa.PublicKey | *rsa.PrivateKey](key Key) *RSAPayload {
 	payload := new(RSAPayload)
 

--- a/jwk/source.go
+++ b/jwk/source.go
@@ -10,22 +10,27 @@ import (
 	"github.com/a-novel-kit/jwt/jwa"
 )
 
+// ErrKeyNotFound is returned by [Source.Get] when no cached key matches the request.
 var ErrKeyNotFound = errors.New("key not found")
 
-// KeysFetcher is a function that fetches keys from a source. The keys MUST be sorted by priority, with top-most keys
-// being the most important.
+// KeysFetcher retrieves the raw JSON Web Keys backing a [Source]. Keys must be returned in
+// priority order, most important first, because [Source.Get] falls back to the first key when no
+// ID is requested.
 type KeysFetcher func(ctx context.Context) ([]*jwa.JWK, error)
 
-// KeyParser decodes keys from a source into a consumable format.
+// KeyParser decodes a raw JSON Web Key into a typed [Key].
 type KeyParser[K any] func(ctx context.Context, jwk *jwa.JWK) (*Key[K], error)
 
+// SourceConfig configures a [Source].
 type SourceConfig struct {
-	// How long keys are cached before being refreshed.
+	// CacheDuration is how long fetched keys are held before the next fetch.
 	CacheDuration time.Duration
-	// Method used to refresh keys.
+	// Fetch retrieves the current keys.
 	Fetch KeysFetcher
 }
 
+// A Source fetches, caches, and parses the keys used to sign or verify tokens. It refreshes lazily
+// once the cached set is older than CacheDuration, and is safe for concurrent use.
 type Source[K any] struct {
 	config SourceConfig
 	parser KeyParser[K]
@@ -66,7 +71,7 @@ func (source *Source[K]) refresh(ctx context.Context) error {
 	return nil
 }
 
-// List every key available.
+// List returns every cached key, refreshing the cache first when it has expired.
 func (source *Source[K]) List(ctx context.Context) ([]*Key[K], error) {
 	err := source.refresh(ctx)
 	if err != nil {
@@ -79,7 +84,8 @@ func (source *Source[K]) List(ctx context.Context) ([]*Key[K], error) {
 	return source.cached, nil
 }
 
-// Get a key using a specific ID. If the KID parameter is empty, the first key available will be returned.
+// Get returns the key with the given ID. An empty kid returns the first (highest-priority) key. It
+// returns ErrKeyNotFound when the source is empty or no key matches.
 func (source *Source[K]) Get(ctx context.Context, kid string) (*Key[K], error) {
 	list, err := source.List(ctx)
 	if err != nil {
@@ -103,6 +109,8 @@ func (source *Source[K]) Get(ctx context.Context, kid string) (*Key[K], error) {
 	return nil, fmt.Errorf("(Source.Get) %w", ErrKeyNotFound)
 }
 
+// NewGenericSource builds a [Source] from a config and a parser. The algorithm-specific
+// constructors, such as [NewRSAPublicSource], wrap this with a preset-bound parser.
 func NewGenericSource[K any](config SourceConfig, parser KeyParser[K]) *Source[K] {
 	return &Source[K]{
 		config:     config,

--- a/jwp/claims_checker.go
+++ b/jwp/claims_checker.go
@@ -10,20 +10,31 @@ import (
 	"github.com/a-novel-kit/jwt/jwa"
 )
 
+// ErrInvalidClaims wraps every failure reported by a claims check, so callers can detect a rejected
+// token by identity while the wrapped error carries which check failed. Returned by
+// [ClaimsChecker.Unmarshal].
 var ErrInvalidClaims = errors.New("invalid claims")
 
+// A RawClaimsCheck validates a token's payload from its raw JSON bytes, before any decoding. Use it
+// for custom claims that are not part of the registered [jwa.Claims] set. CheckRaw returns an error
+// to reject the token.
 type RawClaimsCheck interface {
 	CheckRaw(raw []byte) error
 }
 
+// A ClaimsCheck validates the registered claims of a token after they are decoded. CheckClaims
+// returns an error to reject the token.
 type ClaimsCheck interface {
 	CheckClaims(claims *jwa.Claims) error
 }
 
+// A ClaimsCheckTarget rejects a token whose audience, issuer, or subject does not match the expected
+// target. It implements [ClaimsCheck].
 type ClaimsCheckTarget struct {
 	target jwt.TargetConfig
 }
 
+// NewClaimsCheckTarget returns a [ClaimsCheck] that accepts only tokens matching the given target.
 func NewClaimsCheckTarget(target jwt.TargetConfig) *ClaimsCheckTarget {
 	return &ClaimsCheckTarget{
 		target: target,
@@ -55,11 +66,16 @@ func (claimsCheck *ClaimsCheckTarget) CheckClaims(claims *jwa.Claims) error {
 	return nil
 }
 
+// A ClaimsCheckTimestamp rejects a token that has expired or is not yet valid, comparing the "exp"
+// and "nbf" claims against the current time. It implements [ClaimsCheck].
 type ClaimsCheckTimestamp struct {
 	leeway     time.Duration
 	requireExp bool
 }
 
+// NewClaimsCheckTimestamp returns a [ClaimsCheck] that validates the token's time bounds. The leeway
+// widens the accepted window on both ends to absorb clock skew. When requireExp is true, a token
+// without an "exp" claim is rejected.
 func NewClaimsCheckTimestamp(leeway time.Duration, requireExp bool) *ClaimsCheckTimestamp {
 	return &ClaimsCheckTimestamp{
 		leeway:     leeway,
@@ -90,11 +106,16 @@ func (claimsCheck *ClaimsCheckTimestamp) CheckClaims(claims *jwa.Claims) error {
 	return nil
 }
 
+// A RawClaimsChecker adapts an arbitrary callback into a [RawClaimsCheck], passing a caller-supplied
+// config of type T alongside the raw payload on every check. Use it to validate custom claims
+// without declaring a dedicated type.
 type RawClaimsChecker[T any] struct {
 	config   T
 	callback func(raw []byte, config T) error
 }
 
+// NewRawClaimsChecker returns a [RawClaimsCheck] that runs the callback against each token's raw
+// payload, threading config through to it.
 func NewRawClaimsChecker[T any](config T, callback func(raw []byte, config T) error) *RawClaimsChecker[T] {
 	return &RawClaimsChecker[T]{
 		config:   config,
@@ -106,25 +127,35 @@ func (claimsCheck *RawClaimsChecker[T]) CheckRaw(raw []byte) error {
 	return claimsCheck.callback(raw, claimsCheck.config)
 }
 
+// A ClaimsCheckerConfig lists the validations a [ClaimsChecker] runs before it decodes a token's
+// payload.
 type ClaimsCheckerConfig struct {
-	Checks    []ClaimsCheck
+	// Checks run against the decoded registered claims.
+	Checks []ClaimsCheck
+	// ChecksRaw run against the raw payload bytes, for claims outside the registered set.
 	ChecksRaw []RawClaimsCheck
 
-	// Set a custom deserializer to decode the token's payload. Uses json.Unmarshal by default.
+	// Deserializer decodes the validated payload into the destination. Defaults to json.Unmarshal.
 	Deserializer func(raw []byte, dst any) error
 }
 
+// A ClaimsChecker is a payload deserializer that validates a token's claims before decoding it. It
+// plugs into the recipient as the claims unmarshaler, rejecting the token with [ErrInvalidClaims]
+// when any configured check fails.
 type ClaimsChecker struct {
 	config ClaimsCheckerConfig
 }
 
-// NewClaimsChecker is a custom claims unmarshaler, that performs extra checks on the claims.
+// NewClaimsChecker returns a [ClaimsChecker] that runs the configured checks on each token before
+// decoding its payload.
 func NewClaimsChecker(config *ClaimsCheckerConfig) *ClaimsChecker {
 	return &ClaimsChecker{
 		config: *config,
 	}
 }
 
+// Unmarshal runs every configured check against the token's claims, then decodes the payload into
+// dst. It returns [ErrInvalidClaims] as soon as a check rejects the token, leaving dst untouched.
 func (checker *ClaimsChecker) Unmarshal(raw []byte, dst any) error {
 	var token *jwa.Claims
 

--- a/jwp/key_embedder.go
+++ b/jwp/key_embedder.go
@@ -8,25 +8,31 @@ import (
 	"github.com/a-novel-kit/jwt/jwk"
 )
 
+// An EmbedKeyConfig configures how an [EmbedKey] advertises the signing key in a token's header: by
+// identifier, by URL, or by embedding the key itself.
 type EmbedKeyConfig[K any] struct {
-	// Source to get the key from. Optional, overrides Key if set.
+	// Key source resolved at signing time. When set, it supersedes Key.
 	Source *jwk.Source[K]
-	// JSON Web Key to embed. This is optional, and is overridden by Source if set.
+	// JSON Web Key to embed directly. Ignored when Source is set.
 	Key *jwa.JWK
-	// ID of the key. If a Source is set, it will be used to retrieve the specific key.
-	// If not provided, this parameter is automatically set using Key or Source, if present.
+	// Identifier of the key. With a Source set, it selects which key to fetch. Left empty, it is
+	// filled from the resolved key.
 	KID string
-	// URL to retrieve the key from. Optional.
+	// JWK Set URL recorded in the header's "jku" field, telling recipients where to fetch the key.
 	URL string
-	// Embed the key. By default, only the KID is provided to save space. If this parameter is used, and a key is
-	// provided, it will be fully embedded in the header.
+	// Embed writes the full key into the header. When false, only the identifier is written, to
+	// keep the token small.
 	Embed bool
 }
 
+// An EmbedKey records the signing key in a token's header so recipients can locate it, as a
+// [jwt.ProducerStaticPlugin]. Build one with [NewEmbedKey].
 type EmbedKey[K any] struct {
 	config EmbedKeyConfig[K]
 }
 
+// Header writes the key's identifier, URL, and — when configured — the key itself into the token
+// header.
 func (plugin *EmbedKey[K]) Header(ctx context.Context, header *jwa.JWH) (*jwa.JWH, error) {
 	key := plugin.config.Key
 	kid := plugin.config.KID
@@ -54,7 +60,8 @@ func (plugin *EmbedKey[K]) Header(ctx context.Context, header *jwa.JWH) (*jwa.JW
 	return header, nil
 }
 
-// NewEmbedKey is a plugin that embeds a key in the header of a token. You can use this as a jwt.ProducerStaticPlugin.
+// NewEmbedKey returns an [EmbedKey] that advertises the signing key in the token header. Use it as a
+// [jwt.ProducerStaticPlugin].
 func NewEmbedKey[K any](config EmbedKeyConfig[K]) *EmbedKey[K] {
 	return &EmbedKey[K]{config: config}
 }

--- a/jws/common.go
+++ b/jws/common.go
@@ -2,4 +2,7 @@ package jws
 
 import "errors"
 
+// ErrInvalidSignature is returned by a verifier when a token's signature does not match its header
+// and payload, or when the signature is malformed. A source-backed verifier also returns it once no
+// candidate key accepts the token.
 var ErrInvalidSignature = errors.New("invalid signature")

--- a/jws/ecdsa.go
+++ b/jws/ecdsa.go
@@ -16,6 +16,9 @@ import (
 	"github.com/a-novel-kit/jwt/jwk"
 )
 
+// An ECDSAPreset bundles the curve, hash, and algorithm identifier for one ECDSA signing scheme.
+// Pass one of the exported presets to the ECDSA constructors rather than assembling the fields by
+// hand.
 type ECDSAPreset struct {
 	Hash crypto.Hash
 	Alg  jwa.Alg
@@ -23,16 +26,19 @@ type ECDSAPreset struct {
 }
 
 var (
+	// ES256 is ECDSA using the P-256 curve and SHA-256.
 	ES256 = ECDSAPreset{
 		Hash: crypto.SHA256,
 		Alg:  jwa.ES256,
 		Crv:  elliptic.P256(),
 	}
+	// ES384 is ECDSA using the P-384 curve and SHA-384.
 	ES384 = ECDSAPreset{
 		Hash: crypto.SHA384,
 		Alg:  jwa.ES384,
 		Crv:  elliptic.P384(),
 	}
+	// ES512 is ECDSA using the P-521 curve and SHA-512.
 	ES512 = ECDSAPreset{
 		Hash: crypto.SHA512,
 		Alg:  jwa.ES512,
@@ -40,6 +46,8 @@ var (
 	}
 )
 
+// inferECDSAKeySize returns the byte width of a coordinate on the given curve, rounding up when the
+// bit size is not a multiple of eight. JWS pads both signature halves to this width.
 func inferECDSAKeySize(params *elliptic.CurveParams) int {
 	curveBits := params.BitSize
 	keyBytes := curveBits / 8
@@ -51,6 +59,7 @@ func inferECDSAKeySize(params *elliptic.CurveParams) int {
 	return keyBytes
 }
 
+// An ECDSASigner signs tokens with ECDSA as a [jwt.ProducerPlugin]. Build one with [NewECDSASigner].
 type ECDSASigner struct {
 	secretKey *ecdsa.PrivateKey
 
@@ -59,14 +68,10 @@ type ECDSASigner struct {
 	crv  elliptic.Curve
 }
 
-// NewECDSASigner creates a new jwt.ProducerPlugin for a signed token using ECDSA.
+// NewECDSASigner returns a [jwt.ProducerPlugin] that signs tokens with ECDSA, using the curve and
+// hash carried by the preset (one of [ES256], [ES384], [ES512]).
 //
-// Use any of the ECDSAPreset constants to configure the signing parameters.
-//   - ES256: ECDSA using P-256 and SHA-256
-//   - ES384: ECDSA using P-384 and SHA-384
-//   - ES512: ECDSA using P-521 and SHA-512
-//
-// https://datatracker.ietf.org/doc/html/rfc7518#section-3.4
+// See RFC 7518, section 3.4: https://datatracker.ietf.org/doc/html/rfc7518#section-3.4
 func NewECDSASigner(secretKey *ecdsa.PrivateKey, preset ECDSAPreset) *ECDSASigner {
 	return &ECDSASigner{
 		secretKey: secretKey,
@@ -106,12 +111,11 @@ func (signer *ECDSASigner) Transform(_ context.Context, _ *jwa.JWH, rawToken str
 
 	keyBytes := inferECDSAKeySize(signer.secretKey.Params())
 
-	// We serialize the outputs (r and s) into big-endian byte arrays
-	// padded with zeros on the left to make sure the sizes work out.
-	// Output must be 2*keyBytes long.
+	// JWS encodes an ECDSA signature as the fixed-width concatenation R || S, each value big-endian
+	// and left-padded to the curve's coordinate size — not the ASN.1 DER that crypto/ecdsa returns.
 	signature := make([]byte, 2*keyBytes)
-	r.FillBytes(signature[0:keyBytes]) // r is assigned to the first half of output.
-	s.FillBytes(signature[keyBytes:])  // s is assigned to the second half of output.
+	r.FillBytes(signature[0:keyBytes])
+	s.FillBytes(signature[keyBytes:])
 
 	return jwt.SignedToken{
 		Header:    token.Header,
@@ -120,20 +124,18 @@ func (signer *ECDSASigner) Transform(_ context.Context, _ *jwa.JWH, rawToken str
 	}.String(), nil
 }
 
+// An ECDSAVerifier verifies ECDSA-signed tokens as a [jwt.RecipientPlugin]. Build one with
+// [NewECDSAVerifier]. It returns [ErrInvalidSignature] when the signature does not match.
 type ECDSAVerifier struct {
 	publicKey *ecdsa.PublicKey
 	alg       jwa.Alg
 	hash      crypto.Hash
 }
 
-// NewECDSAVerifier creates a new jwt.RecipientPlugin for a signed token using ECDSA.
+// NewECDSAVerifier returns a [jwt.RecipientPlugin] that verifies ECDSA-signed tokens, using the
+// curve and hash carried by the preset (one of [ES256], [ES384], [ES512]).
 //
-// Use any of the ECDSAPreset constants to configure the verification parameters.
-//   - ES256: ECDSA using P-256 and SHA-256
-//   - ES384: ECDSA using P-384 and SHA-384
-//   - ES512: ECDSA using P-521 and SHA-512
-//
-// https://datatracker.ietf.org/doc/html/rfc7518#section-3.4
+// See RFC 7518, section 3.4: https://datatracker.ietf.org/doc/html/rfc7518#section-3.4
 func NewECDSAVerifier(publicKey *ecdsa.PublicKey, preset ECDSAPreset) *ECDSAVerifier {
 	return &ECDSAVerifier{
 		publicKey: publicKey,
@@ -185,19 +187,19 @@ func (verifier *ECDSAVerifier) Transform(_ context.Context, header *jwa.JWH, raw
 	return decoded, nil
 }
 
+// A SourcedECDSASigner signs like an [ECDSASigner] but resolves its key from a [jwk.Source] at each
+// call, so the plugin follows key rotation instead of pinning one key. Build one with
+// [NewSourcedECDSASigner].
 type SourcedECDSASigner struct {
 	source *jwk.Source[*ecdsa.PrivateKey]
 	preset ECDSAPreset
 }
 
-// NewSourcedECDSASigner creates a new jwt.ProducerPlugin for a signed token using ECDSA.
+// NewSourcedECDSASigner returns a [jwt.ProducerPlugin] that signs tokens with ECDSA, drawing the key
+// from the source for the header's KID. The preset (one of [ES256], [ES384], [ES512]) selects the
+// curve and hash.
 //
-// Use any of the ECDSAPreset constants to configure the signing parameters.
-//   - ES256: ECDSA using P-256 and SHA-256
-//   - ES384: ECDSA using P-384 and SHA-384
-//   - ES512: ECDSA using P-521 and SHA-512
-//
-// https://datatracker.ietf.org/doc/html/rfc7518#section-3.4
+// See RFC 7518, section 3.4: https://datatracker.ietf.org/doc/html/rfc7518#section-3.4
 func NewSourcedECDSASigner(source *jwk.Source[*ecdsa.PrivateKey], preset ECDSAPreset) *SourcedECDSASigner {
 	return &SourcedECDSASigner{
 		source: source,
@@ -211,7 +213,7 @@ func (signer *SourcedECDSASigner) Header(ctx context.Context, header *jwa.JWH) (
 		return nil, fmt.Errorf("(SourcedECDSASigner.Header) %w", err)
 	}
 
-	// If the KID was not set, update it.
+	// Stamp the resolved key's ID into the header so recipients can select it for verification.
 	if header.KID == "" {
 		header.KID = key.KID
 	}
@@ -228,19 +230,19 @@ func (signer *SourcedECDSASigner) Transform(ctx context.Context, header *jwa.JWH
 	return NewECDSASigner(key.Key(), signer.preset).Transform(ctx, header, rawToken)
 }
 
+// A SourcedECDSAVerifier verifies like an [ECDSAVerifier] but resolves candidate keys from a
+// [jwk.Source] at each call. When the token names a KID it tries only that key; otherwise it tries
+// every key in the source. Build one with [NewSourcedECDSAVerifier].
 type SourcedECDSAVerifier struct {
 	source *jwk.Source[*ecdsa.PublicKey]
 	preset ECDSAPreset
 }
 
-// NewSourcedECDSAVerifier creates a new jwt.RecipientPlugin for a signed token using ECDSA.
+// NewSourcedECDSAVerifier returns a [jwt.RecipientPlugin] that verifies ECDSA-signed tokens against
+// keys drawn from the source. The preset (one of [ES256], [ES384], [ES512]) selects the curve and
+// hash.
 //
-// Use any of the ECDSAPreset constants to configure the verification parameters.
-//   - ES256: ECDSA using P-256 and SHA-256
-//   - ES384: ECDSA using P-384 and SHA-384
-//   - ES512: ECDSA using P-521 and SHA-512
-//
-// https://datatracker.ietf.org/doc/html/rfc7518#section-3.4
+// See RFC 7518, section 3.4: https://datatracker.ietf.org/doc/html/rfc7518#section-3.4
 func NewSourcedECDSAVerifier(source *jwk.Source[*ecdsa.PublicKey], preset ECDSAPreset) *SourcedECDSAVerifier {
 	return &SourcedECDSAVerifier{
 		source: source,
@@ -255,7 +257,7 @@ func (verifier *SourcedECDSAVerifier) Transform(ctx context.Context, header *jwa
 	}
 
 	for _, key := range keys {
-		// If a KID is set, no need to try with every key.
+		// A token that names a KID can only match that key; skip the rest.
 		if header.KID != "" && key.KID != header.KID {
 			continue
 		}

--- a/jws/ed25519.go
+++ b/jws/ed25519.go
@@ -12,13 +12,15 @@ import (
 	"github.com/a-novel-kit/jwt/jwk"
 )
 
+// An ED25519Signer signs tokens with the Ed25519 EdDSA scheme as a [jwt.ProducerPlugin]. Build one
+// with [NewED25519Signer].
 type ED25519Signer struct {
 	secretKey ed25519.PrivateKey
 }
 
-// NewED25519Signer creates a new jwt.ProducerPlugin for a signed token using Edwards-Curve Digital Signature Algorithm.
+// NewED25519Signer returns a [jwt.ProducerPlugin] that signs tokens with Ed25519 (EdDSA).
 //
-// https://datatracker.ietf.org/doc/html/rfc8032#section-3.3
+// See RFC 8032, section 3.3: https://datatracker.ietf.org/doc/html/rfc8032#section-3.3
 func NewED25519Signer(secretKey ed25519.PrivateKey) *ED25519Signer {
 	return &ED25519Signer{
 		secretKey: secretKey,
@@ -50,14 +52,15 @@ func (signer *ED25519Signer) Transform(_ context.Context, _ *jwa.JWH, rawToken s
 	}.String(), nil
 }
 
+// An ED25519Verifier verifies Ed25519-signed tokens as a [jwt.RecipientPlugin]. Build one with
+// [NewED25519Verifier]. It returns [ErrInvalidSignature] when the signature does not match.
 type ED25519Verifier struct {
 	publicKey ed25519.PublicKey
 }
 
-// NewED25519Verifier creates a new jwt.RecipientPlugin for a signed token using Edwards-Curve Digital Signature
-// Algorithm.
+// NewED25519Verifier returns a [jwt.RecipientPlugin] that verifies Ed25519-signed (EdDSA) tokens.
 //
-// https://datatracker.ietf.org/doc/html/rfc8032#section-3.3
+// See RFC 8032, section 3.3: https://datatracker.ietf.org/doc/html/rfc8032#section-3.3
 func NewED25519Verifier(publicKey ed25519.PublicKey) *ED25519Verifier {
 	return &ED25519Verifier{
 		publicKey: publicKey,
@@ -96,14 +99,17 @@ func (verifier *ED25519Verifier) Transform(_ context.Context, header *jwa.JWH, r
 	return decoded, nil
 }
 
+// A SourcedED25519Signer signs like an [ED25519Signer] but resolves its key from a [jwk.Source] at
+// each call, so the plugin follows key rotation instead of pinning one key. Build one with
+// [NewSourcedED25519Signer].
 type SourcedED25519Signer struct {
 	source *jwk.Source[ed25519.PrivateKey]
 }
 
-// NewSourcedED25519Signer creates a new jwt.ProducerPlugin for a signed token using Edwards-Curve Digital
-// Signature Algorithm.
+// NewSourcedED25519Signer returns a [jwt.ProducerPlugin] that signs tokens with Ed25519 (EdDSA),
+// drawing the key from the source for the header's KID.
 //
-// https://datatracker.ietf.org/doc/html/rfc8032#section-3.3
+// See RFC 8032, section 3.3: https://datatracker.ietf.org/doc/html/rfc8032#section-3.3
 func NewSourcedED25519Signer(source *jwk.Source[ed25519.PrivateKey]) *SourcedED25519Signer {
 	return &SourcedED25519Signer{
 		source: source,
@@ -116,7 +122,7 @@ func (signer *SourcedED25519Signer) Header(ctx context.Context, header *jwa.JWH)
 		return nil, fmt.Errorf("(SourcedED25519Signer.Header) %w", err)
 	}
 
-	// If the KID was not set, update it.
+	// Stamp the resolved key's ID into the header so recipients can select it for verification.
 	if header.KID == "" {
 		header.KID = key.KID
 	}
@@ -133,14 +139,17 @@ func (signer *SourcedED25519Signer) Transform(ctx context.Context, header *jwa.J
 	return NewED25519Signer(key.Key()).Transform(ctx, header, rawToken)
 }
 
+// A SourcedED25519Verifier verifies like an [ED25519Verifier] but resolves candidate keys from a
+// [jwk.Source] at each call. When the token names a KID it tries only that key; otherwise it tries
+// every key in the source. Build one with [NewSourcedED25519Verifier].
 type SourcedED25519Verifier struct {
 	source *jwk.Source[ed25519.PublicKey]
 }
 
-// NewSourcedED25519Verifier creates a new jwt.RecipientPlugin for a signed token using Edwards-Curve Digital
-// Signature Algorithm.
+// NewSourcedED25519Verifier returns a [jwt.RecipientPlugin] that verifies Ed25519-signed (EdDSA)
+// tokens against keys drawn from the source.
 //
-// https://datatracker.ietf.org/doc/html/rfc8032#section-3.3
+// See RFC 8032, section 3.3: https://datatracker.ietf.org/doc/html/rfc8032#section-3.3
 func NewSourcedED25519Verifier(source *jwk.Source[ed25519.PublicKey]) *SourcedED25519Verifier {
 	return &SourcedED25519Verifier{
 		source: source,
@@ -156,7 +165,7 @@ func (verifier *SourcedED25519Verifier) Transform(
 	}
 
 	for _, key := range keys {
-		// If a KID is set, no need to try with every key.
+		// A token that names a KID can only match that key; skip the rest.
 		if header.KID != "" && key.KID != header.KID {
 			continue
 		}

--- a/jws/hmac.go
+++ b/jws/hmac.go
@@ -13,26 +13,33 @@ import (
 	"github.com/a-novel-kit/jwt/jwk"
 )
 
+// An HMACPreset bundles the hash and algorithm identifier for one HMAC signing scheme. Pass one of
+// the exported presets to the HMAC constructors rather than assembling the fields by hand.
 type HMACPreset struct {
 	Hash crypto.Hash
 	Alg  jwa.Alg
 }
 
 var (
+	// HS256 is HMAC using SHA-256.
 	HS256 = HMACPreset{
 		Hash: crypto.SHA256,
 		Alg:  jwa.HS256,
 	}
+	// HS384 is HMAC using SHA-384.
 	HS384 = HMACPreset{
 		Hash: crypto.SHA384,
 		Alg:  jwa.HS384,
 	}
+	// HS512 is HMAC using SHA-512.
 	HS512 = HMACPreset{
 		Hash: crypto.SHA512,
 		Alg:  jwa.HS512,
 	}
 )
 
+// An HMACSigner signs tokens with HMAC-SHA-2 as a [jwt.ProducerPlugin]. The same secret is used to
+// sign and to verify, so keep it private to the trusted parties. Build one with [NewHMACSigner].
 type HMACSigner struct {
 	secretKey []byte
 
@@ -40,14 +47,10 @@ type HMACSigner struct {
 	hash crypto.Hash
 }
 
-// NewHMACSigner creates a new jwt.ProducerPlugin for a signed token using HMAC with SHA-2.
+// NewHMACSigner returns a [jwt.ProducerPlugin] that signs tokens with HMAC, using the hash carried
+// by the preset (one of [HS256], [HS384], [HS512]).
 //
-// Use any of the HMACPreset constants to configure the signing parameters.
-//   - HS256: HMAC using SHA-256
-//   - HS384: HMAC using SHA-384
-//   - HS512: HMAC using SHA-512
-//
-// https://datatracker.ietf.org/doc/html/rfc7518#section-3.2
+// See RFC 7518, section 3.2: https://datatracker.ietf.org/doc/html/rfc7518#section-3.2
 func NewHMACSigner(secretKey []byte, preset HMACPreset) *HMACSigner {
 	return &HMACSigner{
 		secretKey: secretKey,
@@ -84,6 +87,8 @@ func (signer *HMACSigner) Transform(_ context.Context, _ *jwa.JWH, tokenRaw stri
 	}.String(), nil
 }
 
+// An HMACVerifier verifies HMAC-signed tokens as a [jwt.RecipientPlugin]. Build one with
+// [NewHMACVerifier]. It returns [ErrInvalidSignature] when the signature does not match.
 type HMACVerifier struct {
 	secretKey []byte
 
@@ -91,14 +96,11 @@ type HMACVerifier struct {
 	hash crypto.Hash
 }
 
-// NewHMACVerifier creates a new jwt.RecipientPlugin for a signed token using HMAC with SHA-2.
+// NewHMACVerifier returns a [jwt.RecipientPlugin] that verifies HMAC-signed tokens, using the hash
+// carried by the preset (one of [HS256], [HS384], [HS512]). The secret must match the one used to
+// sign.
 //
-// Use any of the HMACPreset constants to configure the signing parameters.
-//   - HS256: HMAC using SHA-256
-//   - HS384: HMAC using SHA-384
-//   - HS512: HMAC using SHA-512
-//
-// https://datatracker.ietf.org/doc/html/rfc7518#section-3.2
+// See RFC 7518, section 3.2: https://datatracker.ietf.org/doc/html/rfc7518#section-3.2
 func NewHMACVerifier(secretKey []byte, preset HMACPreset) *HMACVerifier {
 	return &HMACVerifier{
 		secretKey: secretKey,
@@ -142,19 +144,19 @@ func (verifier *HMACVerifier) Transform(_ context.Context, header *jwa.JWH, rawT
 	return decoded, nil
 }
 
+// A SourceHMACSigner signs like an [HMACSigner] but resolves its secret from a [jwk.Source] at each
+// call, so the plugin follows key rotation instead of pinning one secret. Build one with
+// [NewSourcedHMACSigner].
 type SourceHMACSigner struct {
 	source *jwk.Source[[]byte]
 	preset HMACPreset
 }
 
-// NewSourcedHMACSigner creates a new jwt.ProducerPlugin for a signed token using HMAC with SHA-2.
+// NewSourcedHMACSigner returns a [jwt.ProducerPlugin] that signs tokens with HMAC, drawing the
+// secret from the source for the header's KID. The preset (one of [HS256], [HS384], [HS512])
+// selects the hash.
 //
-// Use any of the HMACPreset constants to configure the signing parameters.
-//   - HS256: HMAC using SHA-256
-//   - HS384: HMAC using SHA-384
-//   - HS512: HMAC using SHA-512
-//
-// https://datatracker.ietf.org/doc/html/rfc7518#section-3.2
+// See RFC 7518, section 3.2: https://datatracker.ietf.org/doc/html/rfc7518#section-3.2
 func NewSourcedHMACSigner(source *jwk.Source[[]byte], preset HMACPreset) *SourceHMACSigner {
 	return &SourceHMACSigner{
 		source: source,
@@ -168,7 +170,7 @@ func (signer *SourceHMACSigner) Header(ctx context.Context, header *jwa.JWH) (*j
 		return nil, fmt.Errorf("(SourceHMACSigner.Header) %w", err)
 	}
 
-	// If the KID was not set, update it.
+	// Stamp the resolved key's ID into the header so recipients can select it for verification.
 	if header.KID == "" {
 		header.KID = key.KID
 	}
@@ -185,19 +187,18 @@ func (signer *SourceHMACSigner) Transform(ctx context.Context, header *jwa.JWH, 
 	return NewHMACSigner(key.Key(), signer.preset).Transform(ctx, header, rawToken)
 }
 
+// A SourceHMACVerifier verifies like an [HMACVerifier] but resolves candidate secrets from a
+// [jwk.Source] at each call. When the token names a KID it tries only that secret; otherwise it
+// tries every secret in the source. Build one with [NewSourcedHMACVerifier].
 type SourceHMACVerifier struct {
 	source *jwk.Source[[]byte]
 	preset HMACPreset
 }
 
-// NewSourcedHMACVerifier creates a new jwt.RecipientPlugin for a signed token using HMAC with SHA-2.
+// NewSourcedHMACVerifier returns a [jwt.RecipientPlugin] that verifies HMAC-signed tokens against
+// secrets drawn from the source. The preset (one of [HS256], [HS384], [HS512]) selects the hash.
 //
-// Use any of the HMACPreset constants to configure the signing parameters.
-//   - HS256: HMAC using SHA-256
-//   - HS384: HMAC using SHA-384
-//   - HS512: HMAC using SHA-512
-//
-// https://datatracker.ietf.org/doc/html/rfc7518#section-3.2
+// See RFC 7518, section 3.2: https://datatracker.ietf.org/doc/html/rfc7518#section-3.2
 func NewSourcedHMACVerifier(source *jwk.Source[[]byte], preset HMACPreset) *SourceHMACVerifier {
 	return &SourceHMACVerifier{
 		source: source,
@@ -212,7 +213,7 @@ func (verifier *SourceHMACVerifier) Transform(ctx context.Context, header *jwa.J
 	}
 
 	for _, key := range keys {
-		// If a KID is set, no need to try with every key.
+		// A token that names a KID can only match that secret; skip the rest.
 		if header.KID != "" && key.KID != header.KID {
 			continue
 		}

--- a/jws/insecure.go
+++ b/jws/insecure.go
@@ -9,8 +9,14 @@ import (
 	"github.com/a-novel-kit/jwt/jwa"
 )
 
+// An InsecureVerifier decodes a token's payload without checking its signature. It accepts any
+// well-formed token as a [jwt.RecipientPlugin], regardless of who signed it. Use it only when the
+// token's authenticity is already guaranteed by other means — never for tokens from an untrusted
+// source.
 type InsecureVerifier struct{}
 
+// NewInsecureVerifier returns an [InsecureVerifier], a [jwt.RecipientPlugin] that extracts a token's
+// payload without any cryptographic verification. See [InsecureVerifier] for when this is safe.
 func NewInsecureVerifier() *InsecureVerifier {
 	return &InsecureVerifier{}
 }

--- a/jws/rsa.go
+++ b/jws/rsa.go
@@ -14,26 +14,33 @@ import (
 	"github.com/a-novel-kit/jwt/jwk"
 )
 
+// An RSAPreset bundles the hash and algorithm identifier for one RSASSA-PKCS1-v1_5 signing scheme.
+// Pass one of the exported presets to the RSA constructors rather than assembling the fields by hand.
 type RSAPreset struct {
 	Hash crypto.Hash
 	Alg  jwa.Alg
 }
 
 var (
+	// RS256 is RSASSA-PKCS1-v1_5 using SHA-256.
 	RS256 = RSAPreset{
 		Hash: crypto.SHA256,
 		Alg:  jwa.RS256,
 	}
+	// RS384 is RSASSA-PKCS1-v1_5 using SHA-384.
 	RS384 = RSAPreset{
 		Hash: crypto.SHA384,
 		Alg:  jwa.RS384,
 	}
+	// RS512 is RSASSA-PKCS1-v1_5 using SHA-512.
 	RS512 = RSAPreset{
 		Hash: crypto.SHA512,
 		Alg:  jwa.RS512,
 	}
 )
 
+// An RSASigner signs tokens with RSASSA-PKCS1-v1_5 as a [jwt.ProducerPlugin]. Build one with
+// [NewRSASigner].
 type RSASigner struct {
 	secretKey *rsa.PrivateKey
 
@@ -41,15 +48,10 @@ type RSASigner struct {
 	hash crypto.Hash
 }
 
-// NewRSASigner creates a new jwt.ProducerPlugin for a signed token using RSASSA-PKCS1-v1_5.
-// A key of size 2048 bits or larger MUST be used with these algorithms.
+// NewRSASigner returns a [jwt.ProducerPlugin] that signs tokens with RSASSA-PKCS1-v1_5, using the
+// hash carried by the preset (one of [RS256], [RS384], [RS512]). The key must be at least 2048 bits.
 //
-// Use any of the RSAPreset constants to configure the signing parameters.
-//   - RS256: RSASSA-PKCS1-v1_5 using SHA-256
-//   - RS384: RSASSA-PKCS1-v1_5 using SHA-384
-//   - RS512: RSASSA-PKCS1-v1_5 using SHA-512
-//
-// https://datatracker.ietf.org/doc/html/rfc7518#section-3.3
+// See RFC 7518, section 3.3: https://datatracker.ietf.org/doc/html/rfc7518#section-3.3
 func NewRSASigner(secretKey *rsa.PrivateKey, preset RSAPreset) *RSASigner {
 	return &RSASigner{
 		secretKey: secretKey,
@@ -89,6 +91,8 @@ func (signer *RSASigner) Transform(_ context.Context, _ *jwa.JWH, tokenRaw strin
 	}.String(), nil
 }
 
+// An RSAVerifier verifies RSASSA-PKCS1-v1_5-signed tokens as a [jwt.RecipientPlugin]. Build one with
+// [NewRSAVerifier]. It returns [ErrInvalidSignature] when the signature does not match.
 type RSAVerifier struct {
 	publicKey *rsa.PublicKey
 
@@ -96,15 +100,10 @@ type RSAVerifier struct {
 	hash crypto.Hash
 }
 
-// NewRSAVerifier creates a new jwt.RecipientPlugin for a signed token using RSASSA-PKCS1-v1_5.
-// A key of size 2048 bits or larger MUST be used with these algorithms.
+// NewRSAVerifier returns a [jwt.RecipientPlugin] that verifies RSASSA-PKCS1-v1_5-signed tokens,
+// using the hash carried by the preset (one of [RS256], [RS384], [RS512]).
 //
-// Use any of the RSAPreset constants to configure the signing parameters.
-//   - RS256: RSASSA-PKCS1-v1_5 using SHA-256
-//   - RS384: RSASSA-PKCS1-v1_5 using SHA-384
-//   - RS512: RSASSA-PKCS1-v1_5 using SHA-512
-//
-// https://datatracker.ietf.org/doc/html/rfc7518#section-3.3
+// See RFC 7518, section 3.3: https://datatracker.ietf.org/doc/html/rfc7518#section-3.3
 func NewRSAVerifier(publicKey *rsa.PublicKey, preset RSAPreset) *RSAVerifier {
 	return &RSAVerifier{
 		publicKey: publicKey,
@@ -153,20 +152,19 @@ func (verifier *RSAVerifier) Transform(_ context.Context, header *jwa.JWH, rawTo
 	return decoded, nil
 }
 
+// A SourcedRSASigner signs like an [RSASigner] but resolves its key from a [jwk.Source] at each
+// call, so the plugin follows key rotation instead of pinning one key. Build one with
+// [NewSourcedRSASigner].
 type SourcedRSASigner struct {
 	source *jwk.Source[*rsa.PrivateKey]
 	preset RSAPreset
 }
 
-// NewSourcedRSASigner creates a new jwt.ProducerPlugin for a signed token using RSASSA-PKCS1-v1_5.
-// A key of size 2048 bits or larger MUST be used with these algorithms.
+// NewSourcedRSASigner returns a [jwt.ProducerPlugin] that signs tokens with RSASSA-PKCS1-v1_5,
+// drawing the key from the source for the header's KID. The preset (one of [RS256], [RS384],
+// [RS512]) selects the hash, and the key must be at least 2048 bits.
 //
-// Use any of the RSAPreset constants to configure the signing parameters.
-//   - RS256: RSASSA-PKCS1-v1_5 using SHA-256
-//   - RS384: RSASSA-PKCS1-v1_5 using SHA-384
-//   - RS512: RSASSA-PKCS1-v1_5 using SHA-512
-//
-// https://datatracker.ietf.org/doc/html/rfc7518#section-3.3
+// See RFC 7518, section 3.3: https://datatracker.ietf.org/doc/html/rfc7518#section-3.3
 func NewSourcedRSASigner(source *jwk.Source[*rsa.PrivateKey], preset RSAPreset) *SourcedRSASigner {
 	return &SourcedRSASigner{
 		source: source,
@@ -180,7 +178,7 @@ func (signer *SourcedRSASigner) Header(ctx context.Context, header *jwa.JWH) (*j
 		return nil, fmt.Errorf("(SourcedRSASigner.Header) %w", err)
 	}
 
-	// If the KID was not set, update it.
+	// Stamp the resolved key's ID into the header so recipients can select it for verification.
 	if header.KID == "" {
 		header.KID = key.KID
 	}
@@ -197,20 +195,19 @@ func (signer *SourcedRSASigner) Transform(ctx context.Context, header *jwa.JWH, 
 	return NewRSASigner(key.Key(), signer.preset).Transform(ctx, header, rawToken)
 }
 
+// A SourcedRSAVerifier verifies like an [RSAVerifier] but resolves candidate keys from a
+// [jwk.Source] at each call. When the token names a KID it tries only that key; otherwise it tries
+// every key in the source. Build one with [NewSourcedRSAVerifier].
 type SourcedRSAVerifier struct {
 	source *jwk.Source[*rsa.PublicKey]
 	preset RSAPreset
 }
 
-// NewSourcedRSAVerifier creates a new jwt.RecipientPlugin for a signed token using RSASSA-PKCS1-v1_5.
-// A key of size 2048 bits or larger MUST be used with these algorithms.
+// NewSourcedRSAVerifier returns a [jwt.RecipientPlugin] that verifies RSASSA-PKCS1-v1_5-signed
+// tokens against keys drawn from the source. The preset (one of [RS256], [RS384], [RS512]) selects
+// the hash.
 //
-// Use any of the RSAPreset constants to configure the signing parameters.
-//   - RS256: RSASSA-PKCS1-v1_5 using SHA-256
-//   - RS384: RSASSA-PKCS1-v1_5 using SHA-384
-//   - RS512: RSASSA-PKCS1-v1_5 using SHA-512
-//
-// https://datatracker.ietf.org/doc/html/rfc7518#section-3.3
+// See RFC 7518, section 3.3: https://datatracker.ietf.org/doc/html/rfc7518#section-3.3
 func NewSourcedRSAVerifier(source *jwk.Source[*rsa.PublicKey], preset RSAPreset) *SourcedRSAVerifier {
 	return &SourcedRSAVerifier{
 		source: source,
@@ -227,7 +224,7 @@ func (verifier *SourcedRSAVerifier) Transform(
 	}
 
 	for _, key := range keys {
-		// If a KID is set, no need to try with every key.
+		// A token that names a KID can only match that key; skip the rest.
 		if header.KID != "" && key.KID != header.KID {
 			continue
 		}

--- a/jws/rsa_pss.go
+++ b/jws/rsa_pss.go
@@ -14,26 +14,34 @@ import (
 	"github.com/a-novel-kit/jwt/jwk"
 )
 
+// An RSAPSSPreset bundles the hash and algorithm identifier for one RSASSA-PSS signing scheme.
+// RSASSA-PSS uses the same hash for the digest and for MGF1. Pass one of the exported presets to the
+// RSA-PSS constructors rather than assembling the fields by hand.
 type RSAPSSPreset struct {
 	Hash crypto.Hash
 	Alg  jwa.Alg
 }
 
 var (
+	// PS256 is RSASSA-PSS using SHA-256 and MGF1 with SHA-256.
 	PS256 = RSAPSSPreset{
 		Hash: crypto.SHA256,
 		Alg:  jwa.PS256,
 	}
+	// PS384 is RSASSA-PSS using SHA-384 and MGF1 with SHA-384.
 	PS384 = RSAPSSPreset{
 		Hash: crypto.SHA384,
 		Alg:  jwa.PS384,
 	}
+	// PS512 is RSASSA-PSS using SHA-512 and MGF1 with SHA-512.
 	PS512 = RSAPSSPreset{
 		Hash: crypto.SHA512,
 		Alg:  jwa.PS512,
 	}
 )
 
+// An RSAPSSSigner signs tokens with RSASSA-PSS as a [jwt.ProducerPlugin]. Build one with
+// [NewRSAPSSSigner].
 type RSAPSSSigner struct {
 	secretKey *rsa.PrivateKey
 
@@ -41,16 +49,10 @@ type RSAPSSSigner struct {
 	hash crypto.Hash
 }
 
-// NewRSAPSSSigner creates a new jwt.ProducerPlugin for a signed token using RSASSA-PSS.
+// NewRSAPSSSigner returns a [jwt.ProducerPlugin] that signs tokens with RSASSA-PSS, using the hash
+// carried by the preset (one of [PS256], [PS384], [PS512]). The key must be at least 2048 bits.
 //
-// A key of size 2048 bits or larger MUST be used with this algorithm.
-//
-// Use any of the RSAPSSPreset constants to configure the signing parameters.
-//   - PS256: RSASSA-PSS using SHA-384 and MGF1 with SHA-256
-//   - PS384: RSASSA-PSS using SHA-384 and MGF1 with SHA-384
-//   - PS512: RSASSA-PSS using SHA-512 and MGF1 with SHA-512
-//
-// https://datatracker.ietf.org/doc/html/rfc7518#section-3.5
+// See RFC 7518, section 3.5: https://datatracker.ietf.org/doc/html/rfc7518#section-3.5
 func NewRSAPSSSigner(secretKey *rsa.PrivateKey, preset RSAPSSPreset) *RSAPSSSigner {
 	return &RSAPSSSigner{
 		secretKey: secretKey,
@@ -92,6 +94,8 @@ func (signer *RSAPSSSigner) Transform(_ context.Context, _ *jwa.JWH, tokenRaw st
 	}.String(), nil
 }
 
+// An RSAPSSVerifier verifies RSASSA-PSS-signed tokens as a [jwt.RecipientPlugin]. Build one with
+// [NewRSAPSSVerifier]. It returns [ErrInvalidSignature] when the signature does not match.
 type RSAPSSVerifier struct {
 	publicKey *rsa.PublicKey
 
@@ -99,16 +103,10 @@ type RSAPSSVerifier struct {
 	hash crypto.Hash
 }
 
-// NewRSAPSSVerifier creates a new jwt.RecipientPlugin for a signed token using RSASSA-PSS.
+// NewRSAPSSVerifier returns a [jwt.RecipientPlugin] that verifies RSASSA-PSS-signed tokens, using
+// the hash carried by the preset (one of [PS256], [PS384], [PS512]).
 //
-// A key of size 2048 bits or larger MUST be used with this algorithm.
-//
-// Use any of the RSAPSSPreset constants to configure the signing parameters.
-//   - PS256: RSASSA-PSS using SHA-384 and MGF1 with SHA-256
-//   - PS384: RSASSA-PSS using SHA-384 and MGF1 with SHA-384
-//   - PS512: RSASSA-PSS using SHA-512 and MGF1 with SHA-512
-//
-// https://datatracker.ietf.org/doc/html/rfc7518#section-3.5
+// See RFC 7518, section 3.5: https://datatracker.ietf.org/doc/html/rfc7518#section-3.5
 func NewRSAPSSVerifier(publicKey *rsa.PublicKey, preset RSAPSSPreset) *RSAPSSVerifier {
 	return &RSAPSSVerifier{
 		publicKey: publicKey,
@@ -159,21 +157,19 @@ func (verifier *RSAPSSVerifier) Transform(_ context.Context, header *jwa.JWH, ra
 	return decoded, nil
 }
 
+// A SourcedRSAPSSSigner signs like an [RSAPSSSigner] but resolves its key from a [jwk.Source] at
+// each call, so the plugin follows key rotation instead of pinning one key. Build one with
+// [NewSourcedRSAPSSSigner].
 type SourcedRSAPSSSigner struct {
 	source *jwk.Source[*rsa.PrivateKey]
 	preset RSAPSSPreset
 }
 
-// NewSourcedRSAPSSSigner creates a new jwt.ProducerPlugin for a signed token using RSASSA-PSS.
+// NewSourcedRSAPSSSigner returns a [jwt.ProducerPlugin] that signs tokens with RSASSA-PSS, drawing
+// the key from the source for the header's KID. The preset (one of [PS256], [PS384], [PS512])
+// selects the hash, and the key must be at least 2048 bits.
 //
-// A key of size 2048 bits or larger MUST be used with this algorithm.
-//
-// Use any of the RSAPSSPreset constants to configure the signing parameters.
-//   - PS256: RSASSA-PSS using SHA-384 and MGF1 with SHA-256
-//   - PS384: RSASSA-PSS using SHA-384 and MGF1 with SHA-384
-//   - PS512: RSASSA-PSS using SHA-512 and MGF1 with SHA-512
-//
-// https://datatracker.ietf.org/doc/html/rfc7518#section-3.5
+// See RFC 7518, section 3.5: https://datatracker.ietf.org/doc/html/rfc7518#section-3.5
 func NewSourcedRSAPSSSigner(source *jwk.Source[*rsa.PrivateKey], preset RSAPSSPreset) *SourcedRSAPSSSigner {
 	return &SourcedRSAPSSSigner{
 		source: source,
@@ -187,7 +183,7 @@ func (signer *SourcedRSAPSSSigner) Header(ctx context.Context, header *jwa.JWH) 
 		return nil, fmt.Errorf("(SourcedRSAPSSSigner.Header) %w", err)
 	}
 
-	// If the KID was not set, update it.
+	// Stamp the resolved key's ID into the header so recipients can select it for verification.
 	if header.KID == "" {
 		header.KID = key.KID
 	}
@@ -204,21 +200,18 @@ func (signer *SourcedRSAPSSSigner) Transform(ctx context.Context, header *jwa.JW
 	return NewRSAPSSSigner(key.Key(), signer.preset).Transform(ctx, header, rawToken)
 }
 
+// A SourcedRSAPSSVerifier verifies like an [RSAPSSVerifier] but resolves candidate keys from a
+// [jwk.Source] at each call. When the token names a KID it tries only that key; otherwise it tries
+// every key in the source. Build one with [NewSourcedRSAPSSVerifier].
 type SourcedRSAPSSVerifier struct {
 	source *jwk.Source[*rsa.PublicKey]
 	preset RSAPSSPreset
 }
 
-// NewSourcedRSAPSSVerifier creates a new jwt.RecipientPlugin for a signed token using RSASSA-PSS.
+// NewSourcedRSAPSSVerifier returns a [jwt.RecipientPlugin] that verifies RSASSA-PSS-signed tokens
+// against keys drawn from the source. The preset (one of [PS256], [PS384], [PS512]) selects the hash.
 //
-// A key of size 2048 bits or larger MUST be used with this algorithm.
-//
-// Use any of the RSAPSSPreset constants to configure the signing parameters.
-//   - PS256: RSASSA-PSS using SHA-384 and MGF1 with SHA-256
-//   - PS384: RSASSA-PSS using SHA-384 and MGF1 with SHA-384
-//   - PS512: RSASSA-PSS using SHA-512 and MGF1 with SHA-512
-//
-// https://datatracker.ietf.org/doc/html/rfc7518#section-3.5
+// See RFC 7518, section 3.5: https://datatracker.ietf.org/doc/html/rfc7518#section-3.5
 func NewSourcedRSAPSSVerifier(source *jwk.Source[*rsa.PublicKey], preset RSAPSSPreset) *SourcedRSAPSSVerifier {
 	return &SourcedRSAPSSVerifier{
 		source: source,
@@ -235,7 +228,7 @@ func (verifier *SourcedRSAPSSVerifier) Transform(
 	}
 
 	for _, key := range keys {
-		// If a KID is set, no need to try with every key.
+		// A token that names a KID can only match that key; skip the rest.
 		if header.KID != "" && key.KID != header.KID {
 			continue
 		}

--- a/producer.go
+++ b/producer.go
@@ -7,20 +7,27 @@ import (
 	"fmt"
 )
 
+// ProducerConfig configures a Producer: the base header shared by every token and the ordered
+// plugins that sign, encrypt, or otherwise transform each one.
 type ProducerConfig struct {
 	Header HeaderProducerConfig
 
-	// Sorted list of operations to perform on the token.
+	// Plugins run in order. Each describes its operation in the header, then transforms the
+	// serialized token to match.
 	Plugins []ProducerPlugin
-	// StaticPlugins to apply to the token. Those are executed BEFORE the regular operations.
+	// StaticPlugins run before Plugins and only amend the header. They produce intermediate
+	// header values, such as a derived key, that a transforming plugin later consumes.
 	StaticPlugins []ProducerStaticPlugin
 }
 
+// A Producer issues signed or encrypted JWTs from a fixed configuration. Create one with
+// NewProducer and reuse it across tokens.
 type Producer struct {
 	config ProducerConfig
 	header *HeaderProducer
 }
 
+// NewProducer returns a Producer for the given configuration.
 func NewProducer(config ProducerConfig) *Producer {
 	return &Producer{
 		config: config,
@@ -28,13 +35,15 @@ func NewProducer(config ProducerConfig) *Producer {
 	}
 }
 
+// Issue builds a token from customClaims and customHeader, then runs the configured plugins to
+// produce the final serialized JWT.
 func (producer *Producer) Issue(ctx context.Context, customClaims, customHeader any) (string, error) {
 	header, err := producer.header.New(customHeader)
 	if err != nil {
 		return "", fmt.Errorf("(Issuer.Issue) issue header: %w", err)
 	}
 
-	// Transform static operations first.
+	// Static plugins amend the header before the transforming plugins see it.
 	for _, operation := range producer.config.StaticPlugins {
 		header, err = operation.Header(ctx, header)
 		if err != nil {
@@ -42,7 +51,7 @@ func (producer *Producer) Issue(ctx context.Context, customClaims, customHeader 
 		}
 	}
 
-	// Each operation describes itself in the header.
+	// Each plugin records its algorithm and parameters in the header.
 	for _, operation := range producer.config.Plugins {
 		header, err = operation.Header(ctx, header)
 		if err != nil {
@@ -66,7 +75,7 @@ func (producer *Producer) Issue(ctx context.Context, customClaims, customHeader 
 
 	token := headerEncoded + "." + claimsEncoded
 
-	// Transform transformations to the token.
+	// With the header settled and serialized, each plugin applies its transformation to the token.
 	for _, operation := range producer.config.Plugins {
 		token, err = operation.Transform(ctx, header, token)
 		if err != nil {

--- a/producer_claims.go
+++ b/producer_claims.go
@@ -11,13 +11,14 @@ import (
 	"github.com/a-novel-kit/jwt/jwa"
 )
 
-// TargetConfig sets the target of a given set of claims. Target information prevents the token from being misused.
+// TargetConfig scopes a set of claims to an intended context. Recording where a token comes from
+// and who it is for lets a recipient reject one that was replayed against the wrong service.
 type TargetConfig struct {
-	// Issuer of the token. The receiving side MUST filter only tokens that come from trusted producers.
+	// Issuer that produced the token. A recipient should accept only tokens from producers it trusts.
 	Issuer string
-	// Audience of the token. The receiving side MUST filter only tokens that are intended for them.
+	// Audience the token is meant for. A recipient should reject tokens addressed elsewhere.
 	Audience string
-	// Subject of the token. The receiving side MUST filter only tokens that are intended for the given subject.
+	// Subject the token describes. A recipient should reject tokens issued for a different subject.
 	Subject string
 }
 

--- a/producer_header.go
+++ b/producer_header.go
@@ -7,23 +7,31 @@ import (
 	"github.com/a-novel-kit/jwt/jwa"
 )
 
+// HeaderProducerConfig describes the base JOSE header stamped onto every token: its media types,
+// target claims, and the parameters a recipient is required to understand.
 type HeaderProducerConfig struct {
 	TargetConfig
 
 	Typ jwa.Typ
 	CTY jwa.CTY
 
+	// Crit lists custom header parameter names a recipient must process. Every name here has to
+	// appear in the custom header, or building the header fails.
 	Crit []string
 }
 
+// A HeaderProducer builds the base header for each token from a fixed configuration.
 type HeaderProducer struct {
 	config HeaderProducerConfig
 }
 
+// NewHeaderProducer returns a HeaderProducer for the given configuration.
 func NewHeaderProducer(config HeaderProducerConfig) *HeaderProducer {
 	return &HeaderProducer{config: config}
 }
 
+// New builds the base header, folding custom in as the extra header parameters. It fails when a
+// name declared in Crit is missing from custom.
 func (producer *HeaderProducer) New(custom any) (*jwa.JWH, error) {
 	customSerialized, err := json.Marshal(custom)
 	if err != nil {

--- a/producer_plugin.go
+++ b/producer_plugin.go
@@ -8,27 +8,27 @@ import (
 )
 
 var (
+	// ErrConflictingHeader is returned when a plugin needs a header field that an earlier plugin has
+	// already set.
 	ErrConflictingHeader = errors.New("conflicting header")
-	ErrInvalidSecretKey  = errors.New("invalid secret key")
+	// ErrInvalidSecretKey is returned when a plugin's key material does not fit its algorithm, such as
+	// a key size that mismatches the chosen hash.
+	ErrInvalidSecretKey = errors.New("invalid secret key")
 )
 
-// ProducerPlugin is an operation performed on a token to transform it.
-//
-// Each JWT operation MUST do 2 things:
-//   - Describe itself in the header
-//   - Perform a transformation on the final token
-//
-// While this interface is generic, some operations might be exclusive, or require a certain order. If that happens,
-// an operation may fail with the ErrUnsupportedTokenFormat error.
+// A ProducerPlugin transforms a token during issuance. Each plugin does two things: it records its
+// operation in the header, then transforms the serialized token to match — signing or encrypting
+// it, for example. Plugins run in the order they are configured. Because some are mutually
+// exclusive or order-dependent, a plugin may reject a token it cannot apply, for instance with
+// [ErrConflictingHeader] when an earlier plugin already claimed a header field it needs.
 type ProducerPlugin interface {
 	Header(ctx context.Context, header *jwa.JWH) (modifiedHeader *jwa.JWH, err error)
 	Transform(ctx context.Context, header *jwa.JWH, token string) (modifiedToken string, err error)
 }
 
-// ProducerStaticPlugin is much like an ProducerPlugin that does not perform any transformation on the token.
-//
-// Such operations usually produce intermediate values that can be used as an input to a regular operation, such
-// as key derivation.
+// A ProducerStaticPlugin is a plugin that only amends the header and performs no token
+// transformation. It typically derives an intermediate value — a wrapped key, say — that a later
+// transforming plugin consumes.
 type ProducerStaticPlugin interface {
 	Header(ctx context.Context, header *jwa.JWH) (modifiedHeader *jwa.JWH, err error)
 }

--- a/recipient.go
+++ b/recipient.go
@@ -10,18 +10,23 @@ import (
 	"github.com/a-novel-kit/jwt/jwa"
 )
 
+// RecipientConfig configures a Recipient: the ordered plugins that verify or decrypt a token and
+// an optional deserializer for its claims.
 type RecipientConfig struct {
-	// Sorted list of operations to perform on the token.
+	// Plugins run in order until one recognizes the token.
 	Plugins []RecipientPlugin
 
-	// Set a custom deserializer to decode the token's payload. Uses json.Unmarshal by default.
+	// Deserializer decodes the raw claims payload into the destination. Defaults to json.Unmarshal.
 	Deserializer func(raw []byte, dst any) error
 }
 
+// A Recipient verifies and decodes JWTs against a fixed set of plugins.
 type Recipient struct {
 	config RecipientConfig
 }
 
+// NewRecipient returns a Recipient for the given configuration. With no plugins, it falls back to
+// consuming unsecured ("none") tokens.
 func NewRecipient(config RecipientConfig) *Recipient {
 	if config.Plugins == nil {
 		config.Plugins = []RecipientPlugin{NewDefaultRecipientPlugin()}
@@ -32,6 +37,8 @@ func NewRecipient(config RecipientConfig) *Recipient {
 	}
 }
 
+// Consume validates rawToken and decodes its claims into dst. It tries each plugin in order, uses
+// the first that recognizes the token, and fails if none do.
 func (recipient *Recipient) Consume(ctx context.Context, rawToken string, dst any) error {
 	rawHeader, err := DecodeToken(rawToken, &HeaderDecoder{})
 	if err != nil {
@@ -61,6 +68,8 @@ func (recipient *Recipient) Consume(ctx context.Context, rawToken string, dst an
 		recipient.config.Deserializer = json.Unmarshal
 	}
 
+	// A plugin that does not match the token yields ErrMismatchRecipientPlugin; fall through to the
+	// next one. Any other error is fatal.
 	for _, plugin := range recipient.config.Plugins {
 		rawClaims, err := plugin.Transform(ctx, header, rawToken)
 		if err != nil {

--- a/recipient_plugin.go
+++ b/recipient_plugin.go
@@ -9,18 +9,28 @@ import (
 	"github.com/a-novel-kit/jwt/jwa"
 )
 
+// ErrMismatchRecipientPlugin is returned by a plugin that does not recognize a token, signaling
+// the Recipient to try the next plugin instead of failing.
 var ErrMismatchRecipientPlugin = errors.New("mismatch recipient plugin")
 
+// A RecipientPlugin validates a token and extracts its raw claims payload. It returns
+// [ErrMismatchRecipientPlugin] when the token does not match the algorithm or shape it handles, so
+// the Recipient can fall through to another plugin.
 type RecipientPlugin interface {
 	Transform(ctx context.Context, header *jwa.JWH, token string) (payload []byte, err error)
 }
 
+// DefaultRecipientPlugin consumes unsecured tokens: those whose header carries no algorithm or the
+// "none" algorithm. It runs no cryptographic check and returns the payload as it is.
 type DefaultRecipientPlugin struct{}
 
+// NewDefaultRecipientPlugin returns a DefaultRecipientPlugin.
 func NewDefaultRecipientPlugin() *DefaultRecipientPlugin {
 	return &DefaultRecipientPlugin{}
 }
 
+// Transform returns the token's raw payload. It rejects any token that names a real signing or
+// encryption algorithm with [ErrMismatchRecipientPlugin].
 func (plugin *DefaultRecipientPlugin) Transform(_ context.Context, header *jwa.JWH, rawToken string) ([]byte, error) {
 	if header.Alg != "" && header.Alg != jwa.None {
 		return nil, fmt.Errorf(

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
+# Run every package's tests with coverage; -count=1 bypasses the Go test cache so each run executes.
 go tool -modfile=gotestsum.mod gotestsum --format pkgname -- -count=1 -cover ./...

--- a/testutils/jwk.go
+++ b/testutils/jwk.go
@@ -1,3 +1,5 @@
+// Package testutils provides helpers for exercising the jwt packages in tests,
+// standing in for the live key infrastructure a real deployment would rely on.
 package testutils
 
 import (
@@ -9,6 +11,9 @@ import (
 	"github.com/a-novel-kit/jwt/jwk"
 )
 
+// NewStaticKeysSource returns a [jwk.Source] backed by a fixed, in-memory set of keys, so a test can
+// serve known keys without a live JWKS endpoint. Keys are served in the order given, and a lookup
+// matches on KID.
 func NewStaticKeysSource[T any](t *testing.T, keys []*jwk.Key[T]) *jwk.Source[T] {
 	t.Helper()
 

--- a/token.go
+++ b/token.go
@@ -6,14 +6,21 @@ import (
 	"strings"
 )
 
+// ErrUnsupportedTokenFormat is returned when a token does not split into the number of segments a
+// decoder expects.
 var ErrUnsupportedTokenFormat = errors.New("unsupported token format")
 
+// A TokenDecoder splits a compact serialized token into its typed segments. Each JOSE token shape
+// — unsecured, signed, encrypted — has its own decoder producing its own segment type.
 type TokenDecoder[R any] interface {
 	Decode(source string) (R, error)
 }
 
+// HeaderDecoder extracts the encoded header, the first segment, from any compact token regardless
+// of its shape.
 type HeaderDecoder struct{}
 
+// Decode implements [TokenDecoder].
 func (decoder *HeaderDecoder) Decode(source string) (string, error) {
 	parts := strings.Split(source, ".")
 	if len(parts) < 2 {
@@ -23,21 +30,26 @@ func (decoder *HeaderDecoder) Decode(source string) (string, error) {
 	return parts[0], nil
 }
 
+// A RawToken is an unsecured token: a header and payload with no signature or encryption.
 type RawToken struct {
 	Header  string
 	Payload string
 }
 
+// String returns the compact "header.payload" serialization.
 func (token RawToken) String() string {
 	return fmt.Sprintf("%s.%s", token.Header, token.Payload)
 }
 
+// Bytes returns String as a byte slice.
 func (token RawToken) Bytes() []byte {
 	return []byte(token.String())
 }
 
+// RawTokenDecoder decodes an unsecured token into its header and payload segments.
 type RawTokenDecoder struct{}
 
+// Decode implements [TokenDecoder].
 func (decoder *RawTokenDecoder) Decode(source string) (*RawToken, error) {
 	parts := strings.Split(source, ".")
 	if len(parts) != 2 {
@@ -50,22 +62,27 @@ func (decoder *RawTokenDecoder) Decode(source string) (*RawToken, error) {
 	}, nil
 }
 
+// A SignedToken is the three-segment JWS compact form: header, payload, and signature.
 type SignedToken struct {
 	Header    string
 	Payload   string
 	Signature string
 }
 
+// String returns the compact "header.payload.signature" serialization.
 func (token SignedToken) String() string {
 	return fmt.Sprintf("%s.%s.%s", token.Header, token.Payload, token.Signature)
 }
 
+// Bytes returns String as a byte slice.
 func (token SignedToken) Bytes() []byte {
 	return []byte(token.String())
 }
 
+// SignedTokenDecoder decodes a JWS compact token into its three segments.
 type SignedTokenDecoder struct{}
 
+// Decode implements [TokenDecoder].
 func (decoder *SignedTokenDecoder) Decode(source string) (*SignedToken, error) {
 	parts := strings.Split(source, ".")
 	if len(parts) != 3 {
@@ -79,6 +96,8 @@ func (decoder *SignedTokenDecoder) Decode(source string) (*SignedToken, error) {
 	}, nil
 }
 
+// An EncryptedToken is the five-segment JWE compact form: header, encrypted key, initialization
+// vector, ciphertext, and authentication tag.
 type EncryptedToken struct {
 	Header     string
 	EncKey     string
@@ -87,16 +106,20 @@ type EncryptedToken struct {
 	Tag        string
 }
 
+// String returns the compact "header.key.iv.ciphertext.tag" serialization.
 func (token EncryptedToken) String() string {
 	return fmt.Sprintf("%s.%s.%s.%s.%s", token.Header, token.EncKey, token.IV, token.CipherText, token.Tag)
 }
 
+// Bytes returns String as a byte slice.
 func (token EncryptedToken) Bytes() []byte {
 	return []byte(token.String())
 }
 
+// EncryptedTokenDecoder decodes a JWE compact token into its five segments.
 type EncryptedTokenDecoder struct{}
 
+// Decode implements [TokenDecoder].
 func (decoder *EncryptedTokenDecoder) Decode(source string) (*EncryptedToken, error) {
 	parts := strings.Split(source, ".")
 	if len(parts) != 5 {
@@ -112,6 +135,8 @@ func (decoder *EncryptedTokenDecoder) Decode(source string) (*EncryptedToken, er
 	}, nil
 }
 
+// DecodeToken runs decoder over source and returns the typed segments. It lets a caller decode a
+// token by passing the matching decoder rather than naming its segment type.
 func DecodeToken[R any](source string, decoder TokenDecoder[R]) (R, error) {
 	return decoder.Decode(source)
 }


### PR DESCRIPTION
## Summary

Sweeps in-code comments and the project docs (README/CONTRIBUTING) against the sharpened documentation contract: **rationale over restatement**, plain voice, comments paced as navigation. Removes copy-pasted spec text in favor of concise prose plus the authoritative link, adds missing docs on exported symbols, and corrects claims that had drifted from the code.

## Scope

Comments and documentation only — **no code changed** (verified: code tokens are identical after ignoring comments and whitespace across every `.go`/`.ts`/`.proto` file). Excluded: `.github/**` (managed by `a-novel repo update`), `builds/**` (deployment infra), generated/test files, `CODE_OF_CONDUCT`/`LICENSE`.

## Test plan

- [x] Repo formatter is a no-op after the sweep
- [x] Comment-only gate passes
- [ ] CI green