### PR TITLE
fix: correct mislabeled error-source prefixes in wrapped errors

### DIFF
--- a/jws/insecure.go
+++ b/jws/insecure.go
@@ -18,14 +18,14 @@ func NewInsecureVerifier() *InsecureVerifier {
 func (verifier *InsecureVerifier) Transform(_ context.Context, header *jwa.JWH, rawToken string) ([]byte, error) {
 	token, err := jwt.DecodeToken(rawToken, &jwt.SignedTokenDecoder{})
 	if err != nil {
-		return nil, fmt.Errorf("(RSAVerifier.Transform) split token: %w", err)
+		return nil, fmt.Errorf("(InsecureVerifier.Transform) split token: %w", err)
 	}
 
 	unsignedToken := jwt.RawToken{Header: token.Header, Payload: token.Payload}
 
 	decoded, err := base64.RawURLEncoding.DecodeString(unsignedToken.Payload)
 	if err != nil {
-		return nil, fmt.Errorf("(RSAVerifier.Transform) decode payload: %w", err)
+		return nil, fmt.Errorf("(InsecureVerifier.Transform) decode payload: %w", err)
 	}
 
 	return decoded, nil

--- a/jws/insecure_test.go
+++ b/jws/insecure_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/a-novel-kit/jwt"
+	"github.com/a-novel-kit/jwt/jwa"
 	"github.com/a-novel-kit/jwt/jwk"
 	"github.com/a-novel-kit/jwt/jws"
 )
@@ -73,5 +74,19 @@ func TestInsecure(t *testing.T) {
 
 		require.NoError(t, recipient.Consume(t.Context(), otherToken, &recipientClaims))
 		require.Equal(t, producerClaims, recipientClaims)
+	})
+
+	t.Run("MalformedToken", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := verifier.Transform(t.Context(), &jwa.JWH{}, "not-a-token")
+		require.ErrorIs(t, err, jwt.ErrUnsupportedTokenFormat)
+	})
+
+	t.Run("InvalidPayloadEncoding", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := verifier.Transform(t.Context(), &jwa.JWH{}, "header.@@@.signature")
+		require.Error(t, err)
 	})
 }

--- a/jws/rsa_pss.go
+++ b/jws/rsa_pss.go
@@ -145,10 +145,10 @@ func (verifier *RSAPSSVerifier) Transform(_ context.Context, header *jwa.JWH, ra
 	})
 	if err != nil {
 		if errors.Is(err, rsa.ErrVerification) {
-			return nil, errors.Join(fmt.Errorf("(RSAVerifier.Transform) %w", ErrInvalidSignature), err)
+			return nil, errors.Join(fmt.Errorf("(RSAPSSVerifier.Transform) %w", ErrInvalidSignature), err)
 		}
 
-		return nil, fmt.Errorf("(RSAVerifier.Transform) %w", err)
+		return nil, fmt.Errorf("(RSAPSSVerifier.Transform) %w", err)
 	}
 
 	decoded, err := base64.RawURLEncoding.DecodeString(token.Payload)

--- a/producer.go
+++ b/producer.go
@@ -31,14 +31,14 @@ func NewProducer(config ProducerConfig) *Producer {
 func (producer *Producer) Issue(ctx context.Context, customClaims, customHeader any) (string, error) {
 	header, err := producer.header.New(customHeader)
 	if err != nil {
-		return "", fmt.Errorf("(Issuer.Issue) issue header: %w", err)
+		return "", fmt.Errorf("(Producer.Issue) issue header: %w", err)
 	}
 
 	// Transform static operations first.
 	for _, operation := range producer.config.StaticPlugins {
 		header, err = operation.Header(ctx, header)
 		if err != nil {
-			return "", fmt.Errorf("(Issuer.Issue) static operation: %w", err)
+			return "", fmt.Errorf("(Producer.Issue) static operation: %w", err)
 		}
 	}
 
@@ -46,20 +46,20 @@ func (producer *Producer) Issue(ctx context.Context, customClaims, customHeader 
 	for _, operation := range producer.config.Plugins {
 		header, err = operation.Header(ctx, header)
 		if err != nil {
-			return "", fmt.Errorf("(Issuer.Issue) operation: %w", err)
+			return "", fmt.Errorf("(Producer.Issue) operation: %w", err)
 		}
 	}
 
 	claimsSerialized, err := json.Marshal(customClaims)
 	if err != nil {
-		return "", fmt.Errorf("(Issuer.Issue) serialize claims: %w", err)
+		return "", fmt.Errorf("(Producer.Issue) serialize claims: %w", err)
 	}
 
 	claimsEncoded := base64.RawURLEncoding.EncodeToString(claimsSerialized)
 
 	headerSerialized, err := json.Marshal(header)
 	if err != nil {
-		return "", fmt.Errorf("(Issuer.Issue) serialize header: %w", err)
+		return "", fmt.Errorf("(Producer.Issue) serialize header: %w", err)
 	}
 
 	headerEncoded := base64.RawURLEncoding.EncodeToString(headerSerialized)
@@ -70,7 +70,7 @@ func (producer *Producer) Issue(ctx context.Context, customClaims, customHeader 
 	for _, operation := range producer.config.Plugins {
 		token, err = operation.Transform(ctx, header, token)
 		if err != nil {
-			return "", fmt.Errorf("(Issuer.Issue) operation: %w", err)
+			return "", fmt.Errorf("(Producer.Issue) operation: %w", err)
 		}
 	}
 

--- a/producer_test.go
+++ b/producer_test.go
@@ -191,4 +191,22 @@ func TestProducer(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("UnmarshalableClaims", func(t *testing.T) {
+		t.Parallel()
+
+		producer := jwt.NewProducer(jwt.ProducerConfig{})
+
+		_, err := producer.Issue(t.Context(), map[string]any{"bad": make(chan int)}, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("UnmarshalableHeader", func(t *testing.T) {
+		t.Parallel()
+
+		producer := jwt.NewProducer(jwt.ProducerConfig{})
+
+		_, err := producer.Issue(t.Context(), map[string]any{"foo": "bar"}, map[string]any{"bad": make(chan int)})
+		require.Error(t, err)
+	})
 }


### PR DESCRIPTION
## Summary

Copilot's review on #414 flagged several wrapped errors that name the wrong function in their prefix — copy-paste artifacts that mislead anyone reading logs or a stack of `%w`-wrapped errors:

- **`producer.go`** — `Producer.Issue` wraps its errors as `(Issuer.Issue)`. There is no `Issuer` type; the method is `Producer.Issue`. (6 sites — Copilot caught 4, the other 2 are the same bug.)
- **`jws/insecure.go`** — `InsecureVerifier.Transform` wraps errors as `(RSAVerifier.Transform)`.
- **`jws/rsa_pss.go`** — `RSAPSSVerifier.Transform` labels two errors `(RSAVerifier.Transform)` (its other labels are already correct).

Each prefix now matches the method that produces the error.

## Non-breaking

Error **message text** only — no exported signature, type, or behavior changes. No test asserts on these strings; the full suite passes.

## Test plan

- [x] `go test ./...` passes
- [x] `gofmt` clean
- [ ] CI green