### PR TITLE
fix(jwe)!: make DirectKeyManager satisfy the CEKManager interface

### DIFF
--- a/jwe/jwek/direct_encryption.go
+++ b/jwe/jwek/direct_encryption.go
@@ -35,7 +35,7 @@ func (manager *DirectKeyManager) ComputeCEK(_ context.Context, _ *jwa.JWH) ([]by
 	return manager.cek, nil
 }
 
-func (manager *DirectKeyManager) EncryptCEK(_ context.Context, _ []byte) ([]byte, error) {
+func (manager *DirectKeyManager) EncryptCEK(_ context.Context, _ *jwa.JWH, _ []byte) ([]byte, error) {
 	return nil, nil
 }
 

--- a/jwe/jwek/direct_encryption_test.go
+++ b/jwe/jwek/direct_encryption_test.go
@@ -6,9 +6,14 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/a-novel-kit/jwt/jwa"
+	"github.com/a-novel-kit/jwt/jwe"
 	"github.com/a-novel-kit/jwt/jwe/jwek"
 	"github.com/a-novel-kit/jwt/jwk"
 )
+
+// DirectKeyManager plugs into the JWE engine as a jwe.CEKManager ("dir" key management); this
+// assertion keeps its method set matching the interface.
+var _ jwe.CEKManager = (*jwek.DirectKeyManager)(nil)
 
 func TestDirectEncryption(t *testing.T) {
 	t.Parallel()
@@ -25,7 +30,7 @@ func TestDirectEncryption(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, cek.Key(), computedCEK)
 
-	encryptedCEK, err := manager.EncryptCEK(t.Context(), cek.Key())
+	encryptedCEK, err := manager.EncryptCEK(t.Context(), header, cek.Key())
 	require.NoError(t, err)
 	require.Nil(t, encryptedCEK)
 


### PR DESCRIPTION
## Summary

`DirectKeyManager` documents itself as implementing `jwe.CEKManager` (and `NewDirectKeyManager` returns "a jwe.CEKManager"), but its `EncryptCEK` was missing the `*jwa.JWH` header parameter the interface requires:

```
EncryptCEK(ctx, header *jwa.JWH, cek []byte) ([]byte, error)  // jwe.CEKManager
EncryptCEK(ctx, cek []byte) ([]byte, error)                   // DirectKeyManager (before)
```

So the type did **not** satisfy `CEKManager` and could not be passed to the JWE encryption engine — the `"dir"` key-management mode was effectively unusable. Copilot flagged this on #414.

The fix adds the header parameter (the body still returns `nil` — direct mode transmits no wrapped key) and adds a compile-time `var _ jwe.CEKManager = (*jwek.DirectKeyManager)(nil)` assertion in the test so the method set can't silently drift again.

## ⚠️ Breaking change

`DirectKeyManager.EncryptCEK` gains a `*jwa.JWH` argument. Any code calling it directly must add the header. **No consumer across the a-novel / a-novel-kit orgs calls it** (verified by grep), and nothing could have used `DirectKeyManager` as a `CEKManager` before (it didn't satisfy the interface). This warrants a **major** version bump — flagging for your release call.

## Test plan

- [x] `go test ./...` passes — the new interface assertion compiles, proving the type now satisfies `CEKManager`
- [x] `gofmt` clean
- [ ] CI green