### PR TITLE
fix: harden JWT compact parser and recipient (DoS + race)

### DIFF
--- a/recipient.go
+++ b/recipient.go
@@ -48,6 +48,12 @@ func NewRecipient(config RecipientConfig) *Recipient {
 		config.MaxTokenBytes = DefaultMaxTokenBytes
 	}
 
+	// Resolve the default here rather than lazily in Consume: a Recipient is built once and shared
+	// across goroutines, so writing config on first use would be a data race.
+	if config.Deserializer == nil {
+		config.Deserializer = json.Unmarshal
+	}
+
 	return &Recipient{
 		config: config,
 	}
@@ -82,10 +88,6 @@ func (recipient *Recipient) Consume(ctx context.Context, rawToken string, dst an
 		if err != nil {
 			return fmt.Errorf("(Recipient.Consume) check crit: %w", err)
 		}
-	}
-
-	if recipient.config.Deserializer == nil {
-		recipient.config.Deserializer = json.Unmarshal
 	}
 
 	// A plugin that does not match the token yields ErrMismatchRecipientPlugin; fall through to the

--- a/recipient.go
+++ b/recipient.go
@@ -10,6 +10,15 @@ import (
 	"github.com/a-novel-kit/jwt/jwa"
 )
 
+// DefaultMaxTokenBytes bounds the size of an untrusted token Consume will parse when the
+// RecipientConfig does not set a limit. It is deliberately generous — even a JWE carrying an
+// embedded certificate chain stays well under it — while capping the work an attacker can force
+// with an oversized input.
+const DefaultMaxTokenBytes = 1 << 18 // 256 KiB.
+
+// ErrTokenTooLarge is returned by Consume when a token exceeds the configured size limit.
+var ErrTokenTooLarge = errors.New("token exceeds maximum size")
+
 // RecipientConfig configures a Recipient: the ordered plugins that verify or decrypt a token and
 // an optional deserializer for its claims.
 type RecipientConfig struct {
@@ -18,6 +27,9 @@ type RecipientConfig struct {
 
 	// Deserializer decodes the raw claims payload into the destination. Defaults to json.Unmarshal.
 	Deserializer func(raw []byte, dst any) error
+
+	// MaxTokenBytes rejects a token larger than this before any parsing. Zero selects DefaultMaxTokenBytes.
+	MaxTokenBytes int
 }
 
 // A Recipient verifies and decodes JWTs against a fixed set of plugins.
@@ -32,6 +44,10 @@ func NewRecipient(config RecipientConfig) *Recipient {
 		config.Plugins = []RecipientPlugin{NewDefaultRecipientPlugin()}
 	}
 
+	if config.MaxTokenBytes <= 0 {
+		config.MaxTokenBytes = DefaultMaxTokenBytes
+	}
+
 	return &Recipient{
 		config: config,
 	}
@@ -40,6 +56,10 @@ func NewRecipient(config RecipientConfig) *Recipient {
 // Consume validates rawToken and decodes its claims into dst. It tries each plugin in order, uses
 // the first that recognizes the token, and fails if none do.
 func (recipient *Recipient) Consume(ctx context.Context, rawToken string, dst any) error {
+	if len(rawToken) > recipient.config.MaxTokenBytes {
+		return fmt.Errorf("(Recipient.Consume) %w", ErrTokenTooLarge)
+	}
+
 	rawHeader, err := DecodeToken(rawToken, &HeaderDecoder{})
 	if err != nil {
 		return fmt.Errorf("(Recipient.Consume) decode token: %w", err)

--- a/recipient.go
+++ b/recipient.go
@@ -28,7 +28,7 @@ type RecipientConfig struct {
 	// Deserializer decodes the raw claims payload into the destination. Defaults to json.Unmarshal.
 	Deserializer func(raw []byte, dst any) error
 
-	// MaxTokenBytes rejects a token larger than this before any parsing. Zero selects DefaultMaxTokenBytes.
+	// MaxTokenBytes rejects tokens larger than this before parsing. Non-positive selects DefaultMaxTokenBytes.
 	MaxTokenBytes int
 }
 
@@ -63,7 +63,11 @@ func NewRecipient(config RecipientConfig) *Recipient {
 // the first that recognizes the token, and fails if none do.
 func (recipient *Recipient) Consume(ctx context.Context, rawToken string, dst any) error {
 	if len(rawToken) > recipient.config.MaxTokenBytes {
-		return fmt.Errorf("(Recipient.Consume) %w", ErrTokenTooLarge)
+		// Only lengths in the message — never the token itself (a bearer credential).
+		return fmt.Errorf(
+			"(Recipient.Consume) %w: %d bytes exceeds limit %d",
+			ErrTokenTooLarge, len(rawToken), recipient.config.MaxTokenBytes,
+		)
 	}
 
 	rawHeader, err := DecodeToken(rawToken, &HeaderDecoder{})

--- a/recipient_test.go
+++ b/recipient_test.go
@@ -136,6 +136,17 @@ func TestRecipient(t *testing.T) {
 			expectErr: jwt.ErrMismatchRecipientPlugin,
 			expect:    map[string]any{},
 		},
+		{
+			name: "TokenTooLarge",
+
+			config: jwt.RecipientConfig{MaxTokenBytes: 8},
+
+			token: token,
+			dst:   map[string]any{},
+
+			expectErr: jwt.ErrTokenTooLarge,
+			expect:    map[string]any{},
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/recipient_test.go
+++ b/recipient_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -159,4 +160,33 @@ func TestRecipient(t *testing.T) {
 			require.Equal(t, testCase.expect, testCase.dst)
 		})
 	}
+}
+
+func TestRecipientConcurrentConsume(t *testing.T) {
+	t.Parallel()
+
+	producer := jwt.NewProducer(jwt.ProducerConfig{})
+	token, err := producer.Issue(t.Context(), map[string]any{"foo": "bar"}, nil)
+	require.NoError(t, err)
+
+	// A Recipient with a defaulted deserializer is shared across goroutines. The default must be
+	// resolved at construction, not written on first Consume — the latter races under -race.
+	recipient := jwt.NewRecipient(jwt.RecipientConfig{})
+
+	var wg sync.WaitGroup
+
+	for range 16 {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			dst := map[string]any{}
+			if err := recipient.Consume(t.Context(), token, &dst); err != nil {
+				t.Errorf("concurrent consume: %v", err)
+			}
+		}()
+	}
+
+	wg.Wait()
 }

--- a/recipient_test.go
+++ b/recipient_test.go
@@ -182,7 +182,9 @@ func TestRecipientConcurrentConsume(t *testing.T) {
 			defer wg.Done()
 
 			dst := map[string]any{}
-			if err := recipient.Consume(t.Context(), token, &dst); err != nil {
+
+			err := recipient.Consume(t.Context(), token, &dst)
+			if err != nil {
 				t.Errorf("concurrent consume: %v", err)
 			}
 		}()

--- a/token.go
+++ b/token.go
@@ -26,7 +26,8 @@ func (decoder *HeaderDecoder) Decode(source string) (string, error) {
 	// many dots cannot force an unbounded allocation. We only need the first segment, so two suffices.
 	parts := strings.SplitN(source, ".", 2)
 	if len(parts) < 2 {
-		return "", fmt.Errorf("(HeaderDecoder.Decode) %w (%s)", ErrUnsupportedTokenFormat, source)
+		// The token is an untrusted bearer credential — never embed it in the error, only the shape.
+		return "", fmt.Errorf("(HeaderDecoder.Decode) %w: missing header segment", ErrUnsupportedTokenFormat)
 	}
 
 	return parts[0], nil
@@ -57,7 +58,7 @@ func (decoder *RawTokenDecoder) Decode(source string) (*RawToken, error) {
 	// stops a malicious dot-heavy input from allocating an unbounded slice.
 	parts := strings.SplitN(source, ".", 3)
 	if len(parts) != 2 {
-		return nil, fmt.Errorf("(RawTokenDecoder.Decode) %w (%s)", ErrUnsupportedTokenFormat, source)
+		return nil, fmt.Errorf("(RawTokenDecoder.Decode) %w: expected 2 segments", ErrUnsupportedTokenFormat)
 	}
 
 	return &RawToken{
@@ -90,7 +91,7 @@ type SignedTokenDecoder struct{}
 func (decoder *SignedTokenDecoder) Decode(source string) (*SignedToken, error) {
 	parts := strings.SplitN(source, ".", 4)
 	if len(parts) != 3 {
-		return nil, fmt.Errorf("(SignedTokenDecoder.Decode) %w (%s)", ErrUnsupportedTokenFormat, source)
+		return nil, fmt.Errorf("(SignedTokenDecoder.Decode) %w: expected 3 segments", ErrUnsupportedTokenFormat)
 	}
 
 	return &SignedToken{
@@ -127,7 +128,7 @@ type EncryptedTokenDecoder struct{}
 func (decoder *EncryptedTokenDecoder) Decode(source string) (*EncryptedToken, error) {
 	parts := strings.SplitN(source, ".", 6)
 	if len(parts) != 5 {
-		return nil, fmt.Errorf("(EncryptedTokenDecoder.Decode) %w (%s)", ErrUnsupportedTokenFormat, source)
+		return nil, fmt.Errorf("(EncryptedTokenDecoder.Decode) %w: expected 5 segments", ErrUnsupportedTokenFormat)
 	}
 
 	return &EncryptedToken{

--- a/token.go
+++ b/token.go
@@ -22,7 +22,9 @@ type HeaderDecoder struct{}
 
 // Decode implements [TokenDecoder].
 func (decoder *HeaderDecoder) Decode(source string) (string, error) {
-	parts := strings.Split(source, ".")
+	// SplitN caps the slice regardless of how many separators the input carries, so a token made of
+	// many dots cannot force an unbounded allocation. We only need the first segment, so two suffices.
+	parts := strings.SplitN(source, ".", 2)
 	if len(parts) < 2 {
 		return "", fmt.Errorf("(HeaderDecoder.Decode) %w (%s)", ErrUnsupportedTokenFormat, source)
 	}
@@ -51,7 +53,9 @@ type RawTokenDecoder struct{}
 
 // Decode implements [TokenDecoder].
 func (decoder *RawTokenDecoder) Decode(source string) (*RawToken, error) {
-	parts := strings.Split(source, ".")
+	// Limit is segments+1: an over-segmented token still trips the length check below, while the cap
+	// stops a malicious dot-heavy input from allocating an unbounded slice.
+	parts := strings.SplitN(source, ".", 3)
 	if len(parts) != 2 {
 		return nil, fmt.Errorf("(RawTokenDecoder.Decode) %w (%s)", ErrUnsupportedTokenFormat, source)
 	}
@@ -84,7 +88,7 @@ type SignedTokenDecoder struct{}
 
 // Decode implements [TokenDecoder].
 func (decoder *SignedTokenDecoder) Decode(source string) (*SignedToken, error) {
-	parts := strings.Split(source, ".")
+	parts := strings.SplitN(source, ".", 4)
 	if len(parts) != 3 {
 		return nil, fmt.Errorf("(SignedTokenDecoder.Decode) %w (%s)", ErrUnsupportedTokenFormat, source)
 	}
@@ -121,7 +125,7 @@ type EncryptedTokenDecoder struct{}
 
 // Decode implements [TokenDecoder].
 func (decoder *EncryptedTokenDecoder) Decode(source string) (*EncryptedToken, error) {
-	parts := strings.Split(source, ".")
+	parts := strings.SplitN(source, ".", 6)
 	if len(parts) != 5 {
 		return nil, fmt.Errorf("(EncryptedTokenDecoder.Decode) %w (%s)", ErrUnsupportedTokenFormat, source)
 	}

--- a/token.go
+++ b/token.go
@@ -27,7 +27,7 @@ func (decoder *HeaderDecoder) Decode(source string) (string, error) {
 	parts := strings.SplitN(source, ".", 2)
 	if len(parts) < 2 {
 		// The token is an untrusted bearer credential — never embed it in the error, only the shape.
-		return "", fmt.Errorf("(HeaderDecoder.Decode) %w: missing header segment", ErrUnsupportedTokenFormat)
+		return "", fmt.Errorf("(HeaderDecoder.Decode) %w: expected at least 2 segments", ErrUnsupportedTokenFormat)
 	}
 
 	return parts[0], nil

--- a/token_test.go
+++ b/token_test.go
@@ -27,6 +27,12 @@ func TestRawToken(t *testing.T) {
 			name:  "Reject",
 			value: "header.payload.signature",
 		},
+		{
+			// Guards the SplitN limit: extra segments beyond the cap must still be rejected, not
+			// swallowed into the last field.
+			name:  "RejectExtraSegments",
+			value: "a.b.c.d.e.f",
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
## Summary

Task #419 of Epic #430 (JWT security & correctness hardening). Two non-breaking `fix`es:

- **Parser-amplification DoS (S12).** The compact decoders now use `strings.SplitN` (bounded slice), and `Recipient` rejects tokens larger than `DefaultMaxTokenBytes` (256 KiB, configurable via `RecipientConfig.MaxTokenBytes`) *before* parsing — a token made of many `.` can no longer force an unbounded `[]string` allocation. cf. golang-jwt CVE-2025-30204 / go-jose CVE-2025-27144.
- **Deserializer data race (S10).** The `json.Unmarshal` default moves from `Consume` into `NewRecipient`, so a `Recipient` shared across goroutines no longer writes its config on first use.

## Compatibility

Non-breaking — purely additive API (`RecipientConfig.MaxTokenBytes`, `DefaultMaxTokenBytes`, `ErrTokenTooLarge`); the only behaviour change is rejecting oversized / previously-DoS-prone input. Ships in the next minor.

## Test plan

- [x] `go test ./...` passes locally.
- [x] Added `TokenTooLarge`, `RejectExtraSegments`, and `TestRecipientConcurrentConsume` (the last exercises the race fix under `-race`, which runs in CI's `test-go-cli`).

Closes #419