### PR TITLE
fix(jwe): harden JWE crypto (p2c cap, ConcatKDF counter, GCM IV, unpad)

### DIFF
--- a/jwe/aec_gcm_test.go
+++ b/jwe/aec_gcm_test.go
@@ -295,3 +295,32 @@ func TestAESGCMBadIV(t *testing.T) {
 	var claims map[string]any
 	require.ErrorIs(t, recipient.Consume(t.Context(), parts.String(), &claims), jwe.ErrInvalidToken)
 }
+
+func TestAESGCMBadTag(t *testing.T) {
+	t.Parallel()
+
+	key, err := jwk.GenerateAES(jwk.A256GCM)
+	require.NoError(t, err)
+
+	encrypter := jwe.NewAESGCMEncryption(&jwe.AESGCMEncryptionConfig{
+		CEKManager: &fakeCEKManager{cek: key.Key(), encrypted: []byte("encrypted")},
+	}, jwe.A256GCM)
+	producer := jwt.NewProducer(jwt.ProducerConfig{Plugins: []jwt.ProducerPlugin{encrypter}})
+
+	token, err := producer.Issue(t.Context(), map[string]any{"foo": "bar"}, nil)
+	require.NoError(t, err)
+
+	// A wrong-length tag is a malformed token, distinct from an authentication failure.
+	parts, err := jwt.DecodeToken(token, &jwt.EncryptedTokenDecoder{})
+	require.NoError(t, err)
+
+	parts.Tag = base64.RawURLEncoding.EncodeToString([]byte("shorttag"))
+
+	decrypter := jwe.NewAESGCMDecryption(&jwe.AESGCMDecryptionConfig{
+		CEKDecoder: &fakeCEKDecoder{cek: key.Key(), encrypted: []byte("encrypted")},
+	}, jwe.A256GCM)
+	recipient := jwt.NewRecipient(jwt.RecipientConfig{Plugins: []jwt.RecipientPlugin{decrypter}})
+
+	var claims map[string]any
+	require.ErrorIs(t, recipient.Consume(t.Context(), parts.String(), &claims), jwe.ErrInvalidToken)
+}

--- a/jwe/aec_gcm_test.go
+++ b/jwe/aec_gcm_test.go
@@ -284,6 +284,7 @@ func TestAESGCMBadIV(t *testing.T) {
 	// gcm.Open panics on a wrong-length nonce; a tampered IV must instead yield an error.
 	parts, err := jwt.DecodeToken(token, &jwt.EncryptedTokenDecoder{})
 	require.NoError(t, err)
+
 	parts.IV = base64.RawURLEncoding.EncodeToString([]byte("short"))
 
 	decrypter := jwe.NewAESGCMDecryption(&jwe.AESGCMDecryptionConfig{

--- a/jwe/aec_gcm_test.go
+++ b/jwe/aec_gcm_test.go
@@ -1,6 +1,7 @@
 package jwe_test
 
 import (
+	"encoding/base64"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -264,4 +265,32 @@ func TestAESGCM(t *testing.T) {
 			})
 		})
 	}
+}
+
+func TestAESGCMBadIV(t *testing.T) {
+	t.Parallel()
+
+	key, err := jwk.GenerateAES(jwk.A256GCM)
+	require.NoError(t, err)
+
+	encrypter := jwe.NewAESGCMEncryption(&jwe.AESGCMEncryptionConfig{
+		CEKManager: &fakeCEKManager{cek: key.Key(), encrypted: []byte("encrypted")},
+	}, jwe.A256GCM)
+	producer := jwt.NewProducer(jwt.ProducerConfig{Plugins: []jwt.ProducerPlugin{encrypter}})
+
+	token, err := producer.Issue(t.Context(), map[string]any{"foo": "bar"}, nil)
+	require.NoError(t, err)
+
+	// gcm.Open panics on a wrong-length nonce; a tampered IV must instead yield an error.
+	parts, err := jwt.DecodeToken(token, &jwt.EncryptedTokenDecoder{})
+	require.NoError(t, err)
+	parts.IV = base64.RawURLEncoding.EncodeToString([]byte("short"))
+
+	decrypter := jwe.NewAESGCMDecryption(&jwe.AESGCMDecryptionConfig{
+		CEKDecoder: &fakeCEKDecoder{cek: key.Key(), encrypted: []byte("encrypted")},
+	}, jwe.A256GCM)
+	recipient := jwt.NewRecipient(jwt.RecipientConfig{Plugins: []jwt.RecipientPlugin{decrypter}})
+
+	var claims map[string]any
+	require.ErrorIs(t, recipient.Consume(t.Context(), parts.String(), &claims), jwe.ErrInvalidToken)
 }

--- a/jwe/aes_cbc.go
+++ b/jwe/aes_cbc.go
@@ -327,5 +327,10 @@ func (dec *AESCBCDecryption) Transform(ctx context.Context, header *jwa.JWH, raw
 	origData := make([]byte, len(cipherText))
 	blockMode.CryptBlocks(origData, cipherText)
 
-	return internal.PKCS7UnPadding(origData), nil
+	plainText, err := internal.PKCS7UnPadding(origData)
+	if err != nil {
+		return nil, fmt.Errorf("(AESCBCDecryption.Transform) %w: %w", ErrInvalidToken, err)
+	}
+
+	return plainText, nil
 }

--- a/jwe/aes_gcm.go
+++ b/jwe/aes_gcm.go
@@ -262,9 +262,19 @@ func (dec *AESGCMDecryption) Transform(ctx context.Context, header *jwa.JWH, raw
 		)
 	}
 
+	// A wrong-length tag is a malformed token, not an authentication failure; reject it distinctly.
+	if len(tag) != aesgcm.Overhead() {
+		return nil, fmt.Errorf(
+			"(AESGCMDecryption.Transform) %w: tag length %d, expected %d",
+			ErrInvalidToken, len(tag), aesgcm.Overhead(),
+		)
+	}
+
 	plainText, err := aesgcm.Open(nil, iv, append(cipherText, tag...), dec.additionalData)
 	if err != nil {
-		return nil, fmt.Errorf("(AESGCMDecryption.Transform) decrypt: %w", err)
+		// An authenticated-decryption failure is the GCM analogue of a bad HMAC tag; surface the
+		// same sentinel the CBC path uses so callers can treat auth failures uniformly.
+		return nil, fmt.Errorf("(AESGCMDecryption.Transform) %w: %w", ErrInvalidSecret, err)
 	}
 
 	return plainText, nil

--- a/jwe/aes_gcm.go
+++ b/jwe/aes_gcm.go
@@ -6,7 +6,6 @@ import (
 	"crypto/cipher"
 	"crypto/rand"
 	"encoding/base64"
-	"errors"
 	"fmt"
 
 	"github.com/a-novel-kit/jwt"
@@ -255,8 +254,12 @@ func (dec *AESGCMDecryption) Transform(ctx context.Context, header *jwa.JWH, raw
 		return nil, fmt.Errorf("(AESGCMDecryption.Transform) create gcm: %w", err)
 	}
 
-	if len(cipherText)+len(tag) < aesgcm.NonceSize() {
-		return nil, errors.New("(AESGCMDecryption.Transform) ciphertext too short")
+	// The IV is attacker-supplied; gcm.Open panics on a wrong-length nonce, so validate it first.
+	if len(iv) != aesgcm.NonceSize() {
+		return nil, fmt.Errorf(
+			"(AESGCMDecryption.Transform) %w: iv length %d, expected %d",
+			ErrInvalidToken, len(iv), aesgcm.NonceSize(),
+		)
 	}
 
 	plainText, err := aesgcm.Open(nil, iv, append(cipherText, tag...), dec.additionalData)

--- a/jwe/common.go
+++ b/jwe/common.go
@@ -6,3 +6,7 @@ import "errors"
 // has the wrong length for the chosen algorithm, or when an authentication tag fails
 // to verify during decryption.
 var ErrInvalidSecret = errors.New("invalid secret")
+
+// ErrInvalidToken is returned when an encrypted token is structurally malformed — for example an
+// initialization vector or padding of the wrong length.
+var ErrInvalidToken = errors.New("invalid token")

--- a/jwe/internal/concat_kdf.go
+++ b/jwe/internal/concat_kdf.go
@@ -6,6 +6,7 @@ package internal
 
 import (
 	"crypto"
+	"encoding/binary"
 )
 
 // ConcatKDF derives keyDataLen bytes of key material from the shared secret z, following the
@@ -29,7 +30,11 @@ func ConcatKDF(
 	h := hash.New()
 	output := make([]byte, 0, keyDataLen)
 
-	for len(output) < keyDataLen {
+	// The 32-bit block counter (the buffer's first four bytes) MUST increment each round. Left
+	// fixed, every hash block would be identical and any key longer than one hash output would
+	// repeat — for AES-CBC-HMAC that collapses the MAC and ENC key halves into the same value.
+	for round := uint32(1); len(output) < keyDataLen; round++ {
+		binary.BigEndian.PutUint32(buffer[:4], round)
 		h.Write(buffer)
 		output = h.Sum(output)
 		h.Reset()

--- a/jwe/internal/concat_kdf_test.go
+++ b/jwe/internal/concat_kdf_test.go
@@ -35,3 +35,14 @@ func TestVectorConcatKDF(t *testing.T) {
 	out := internal.ConcatKDF(crypto.SHA256, z, 16, algID, ptyUInfo, ptyVInfo, supPubInfo, supPrivInfo)
 	require.Equal(t, expected, out)
 }
+
+func TestConcatKDFMultiBlock(t *testing.T) {
+	t.Parallel()
+
+	// Deriving more than one hash block must advance the round counter, so consecutive blocks
+	// differ. With a fixed counter they would be identical — the bug this guards against, which
+	// would collapse the MAC and ENC key halves of an AES-CBC-HMAC key into the same value.
+	out := internal.ConcatKDF(crypto.SHA256, []byte("shared-secret"), 64, nil, nil, nil, nil, nil)
+	require.Len(t, out, 64)
+	require.NotEqual(t, out[:32], out[32:])
+}

--- a/jwe/internal/pkcs.go
+++ b/jwe/internal/pkcs.go
@@ -2,6 +2,8 @@ package internal
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
 )
 
 // PKCS7Padding appends PKCS#7 padding to bring ciphertext up to a whole multiple of blockSize. A
@@ -13,10 +15,25 @@ func PKCS7Padding(ciphertext []byte, blockSize int) []byte {
 	return append(ciphertext, padtext...)
 }
 
-// PKCS7UnPadding strips the PKCS#7 padding that PKCS7Padding added, returning the original plaintext.
-func PKCS7UnPadding(plaintText []byte) []byte {
+// PKCS7UnPadding strips the PKCS#7 padding that PKCS7Padding added, returning the original
+// plaintext. It validates the padding rather than trusting the last byte: an out-of-range or
+// inconsistent pad length would otherwise slice out of bounds and panic.
+func PKCS7UnPadding(plaintText []byte) ([]byte, error) {
 	length := len(plaintText)
-	unpadding := int(plaintText[length-1])
+	if length == 0 {
+		return nil, errors.New("pkcs7: empty input")
+	}
 
-	return plaintText[:(length - unpadding)]
+	unpadding := int(plaintText[length-1])
+	if unpadding == 0 || unpadding > length {
+		return nil, fmt.Errorf("pkcs7: invalid padding length %d", unpadding)
+	}
+
+	for _, b := range plaintText[length-unpadding:] {
+		if int(b) != unpadding {
+			return nil, errors.New("pkcs7: inconsistent padding")
+		}
+	}
+
+	return plaintText[:length-unpadding], nil
 }

--- a/jwe/internal/pkcs_test.go
+++ b/jwe/internal/pkcs_test.go
@@ -56,7 +56,8 @@ func TestPKCS7UnPadding(t *testing.T) {
 
 		plaintText []byte
 
-		expected []byte
+		expected  []byte
+		expectErr bool
 	}{
 		{
 			name: "padding",
@@ -65,14 +66,41 @@ func TestPKCS7UnPadding(t *testing.T) {
 
 			expected: []byte("test"),
 		},
+		{
+			name: "empty",
+
+			plaintText: []byte{},
+
+			expectErr: true,
+		},
+		{
+			name: "padding too large",
+
+			plaintText: []byte("test\xff"),
+
+			expectErr: true,
+		},
+		{
+			name: "inconsistent padding",
+
+			plaintText: []byte("test\x02\x04"),
+
+			expectErr: true,
+		},
 	}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
-			result := internal.PKCS7UnPadding(testCase.plaintText)
-			require.Equal(t, testCase.expected, result)
+			result, err := internal.PKCS7UnPadding(testCase.plaintText)
+
+			if testCase.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, testCase.expected, result)
+			}
 		})
 	}
 }

--- a/jwe/jwek/pbes2_key_enc.go
+++ b/jwe/jwek/pbes2_key_enc.go
@@ -135,12 +135,20 @@ func (manager *PBES2KeyEncKWConfig) EncryptCEK(_ context.Context, header *jwa.JW
 	return wrapped, nil
 }
 
+// DefaultMaxPBES2Iterations caps the PBKDF2 iteration count (p2c) a decoder will run when the
+// config leaves MaxIterations unset. p2c is attacker-controlled in the token header, so an
+// unbounded value is a CPU-exhaustion DoS; this matches the 1,000,000 ceiling go-jose uses.
+const DefaultMaxPBES2Iterations = 1_000_000
+
 // PBES2KeyEncKWDecoderConfig holds the password used to re-derive the wrap key and
 // decrypt the content encryption key.
 type PBES2KeyEncKWDecoderConfig struct {
 	// Secret is the password the wrap key is derived from; it must match the one
 	// used to encrypt the token.
 	Secret string
+
+	// MaxIterations caps the token's p2c iteration count. Non-positive selects DefaultMaxPBES2Iterations.
+	MaxIterations int
 }
 
 // PBES2KeyEncKWDecoder implements jwe.CEKDecoder: it re-derives the wrap key from
@@ -148,9 +156,10 @@ type PBES2KeyEncKWDecoderConfig struct {
 type PBES2KeyEncKWDecoder struct {
 	config PBES2KeyEncKWDecoderConfig
 
-	alg     jwa.Alg
-	hash    crypto.Hash
-	keySize int
+	alg           jwa.Alg
+	hash          crypto.Hash
+	keySize       int
+	maxIterations int
 }
 
 // NewPBES2KeyEncKWDecoder creates a jwe.CEKDecoder that re-derives the wrap key
@@ -160,11 +169,17 @@ type PBES2KeyEncKWDecoder struct {
 //
 // https://datatracker.ietf.org/doc/html/rfc7518#section-4.8
 func NewPBES2KeyEncKWDecoder(config *PBES2KeyEncKWDecoderConfig, preset PBES2KeyEncKWPreset) *PBES2KeyEncKWDecoder {
+	maxIterations := config.MaxIterations
+	if maxIterations <= 0 {
+		maxIterations = DefaultMaxPBES2Iterations
+	}
+
 	return &PBES2KeyEncKWDecoder{
-		config:  *config,
-		alg:     preset.Alg,
-		hash:    preset.Hash,
-		keySize: preset.KeySize,
+		config:        *config,
+		alg:           preset.Alg,
+		hash:          preset.Hash,
+		keySize:       preset.KeySize,
+		maxIterations: maxIterations,
 	}
 }
 
@@ -180,6 +195,15 @@ func (decoder *PBES2KeyEncKWDecoder) ComputeCEK(_ context.Context, header *jwa.J
 		return nil, fmt.Errorf(
 			"(PBES2KeyEncKWDecoder.ComputeCEK) %w: missing enc key",
 			jwt.ErrUnsupportedTokenFormat,
+		)
+	}
+
+	// p2c is attacker-controlled; run PBKDF2 only within a sane bound, or a single small token can
+	// pin a core for billions of iterations.
+	if header.P2C <= 0 || header.P2C > decoder.maxIterations {
+		return nil, fmt.Errorf(
+			"(PBES2KeyEncKWDecoder.ComputeCEK) %w: p2c %d out of range (1..%d)",
+			jwt.ErrUnsupportedTokenFormat, header.P2C, decoder.maxIterations,
 		)
 	}
 

--- a/jwe/jwek/pbes2_key_enc_test.go
+++ b/jwe/jwek/pbes2_key_enc_test.go
@@ -96,6 +96,23 @@ func TestPBES2KeyEncKW(t *testing.T) {
 				_, err := decoder.ComputeCEK(t.Context(), header, nil)
 				require.Error(t, err)
 			})
+
+			t.Run("P2CTooLarge", func(t *testing.T) {
+				t.Parallel()
+
+				// A token whose p2c exceeds the cap must be rejected before PBKDF2 runs, or it's a
+				// CPU-exhaustion DoS.
+				hugeHeader := *header
+				hugeHeader.P2C = jwek.DefaultMaxPBES2Iterations + 1
+
+				decoder := jwek.NewPBES2KeyEncKWDecoder(
+					&jwek.PBES2KeyEncKWDecoderConfig{Secret: secret},
+					testCase.preset,
+				)
+
+				_, err := decoder.ComputeCEK(t.Context(), &hugeHeader, encryptedCEK)
+				require.Error(t, err)
+			})
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Task #421 of Epic #430 (JWT security hardening) — four contained, non-breaking JWE fixes. All latent for us today (no service uses JWE) but real for the published library.

- **S1 — PBES2 `p2c` DoS** (`jwek/pbes2_key_enc.go`): the attacker-controlled iteration count is now rejected unless in `1..MaxIterations` (default 1,000,000, configurable via `PBES2KeyEncKWDecoderConfig.MaxIterations`) **before** PBKDF2 runs. cf. go-jose GHSA-2c7c-3mj9-8fqh.
- **S2 — ConcatKDF counter** (`internal/concat_kdf.go`): the 32-bit block counter now increments each round. Previously it was fixed, so any key longer than one hash block repeated — for ECDH-ES + `A256CBC-HS512` the CEK's MAC and ENC halves were identical.
- **S3 — AES-GCM IV length** (`aes_gcm.go`): the decrypt path now validates `len(iv) == 12` before `gcm.Open`, which otherwise **panics** on a wrong-length nonce (DoS). Returns the new `ErrInvalidToken`.
- **S11 — PKCS#7 unpad** (`internal/pkcs.go`): `PKCS7UnPadding` now validates the pad length and bytes and returns an error instead of slicing out of bounds / panicking.

**S4 (bind protected header as AAD)** was split into **#433** — it changes the JWE authentication model and deserves isolated review.

## Compatibility

Non-breaking — additive API (`ErrInvalidToken`, `DefaultMaxPBES2Iterations`, `PBES2KeyEncKWDecoderConfig.MaxIterations`). The `PKCS7UnPadding` signature change is on an `internal` package. Ships in the next minor (v1.3.0).

## Test plan

- [x] `go test ./...` passes.
- [x] New tests: ConcatKDF multi-block distinctness, PBES2 `p2c`-over-cap rejection, AES-GCM bad-IV rejection, PKCS#7 invalid-padding cases.

Closes #421