### PR TITLE
fix: enforce recipient understanding of critical (crit) headers

### DIFF
--- a/crit.go
+++ b/crit.go
@@ -10,6 +10,23 @@ import (
 // from the header being checked.
 var ErrMissingCritHeader = errors.New("missing crit header value")
 
+// ErrUnsupportedCritHeader is returned when the "crit" list names an extension the recipient is not
+// configured to understand, or a registered JOSE parameter that a producer must not mark critical.
+var ErrUnsupportedCritHeader = errors.New("unsupported crit header")
+
+// reservedHeaderParams are the header parameters defined by the JWS/JWE/JWA/JWT specifications. A
+// producer MUST NOT mark any of them critical (RFC 7515 §4.1.11), so a recipient rejects a crit
+// list that names one — otherwise "crit" could be used to smuggle contradictory processing rules.
+var reservedHeaderParams = map[string]bool{
+	"alg": true, "jku": true, "jwk": true, "kid": true,
+	"x5u": true, "x5c": true, "x5t": true, "x5t#S256": true,
+	"typ": true, "cty": true, "crit": true,
+	"enc": true, "zip": true,
+	"epk": true, "apu": true, "apv": true,
+	"iv": true, "tag": true, "p2s": true, "p2c": true,
+	"iss": true, "sub": true, "aud": true,
+}
+
 // CheckCrit verifies that every parameter named in crit is present in data, the JSON object of
 // extra header parameters. The JOSE "crit" list marks parameters a recipient is required to
 // understand, so a listed name with no matching value makes the token invalid. An empty crit list
@@ -37,4 +54,33 @@ func CheckCrit(data json.RawMessage, crit []string) error {
 	}
 
 	return nil
+}
+
+// CheckCritUnderstood enforces the recipient's "crit" obligation (RFC 7515 §4.1.11): the token is
+// invalid unless every listed critical extension is understood by the recipient AND present in the
+// header. understood is the set of extension names the recipient is configured to process; any crit
+// entry outside it — or one naming a registered JOSE parameter — is rejected. data is the decoded
+// header (the same JSON object CheckCrit inspects for presence).
+func CheckCritUnderstood(data json.RawMessage, crit, understood []string) error {
+	if len(crit) == 0 {
+		return nil
+	}
+
+	understoodSet := make(map[string]struct{}, len(understood))
+	for _, name := range understood {
+		understoodSet[name] = struct{}{}
+	}
+
+	for _, name := range crit {
+		if reservedHeaderParams[name] {
+			return fmt.Errorf("%w: %q is a registered parameter and must not be critical", ErrUnsupportedCritHeader, name)
+		}
+
+		if _, ok := understoodSet[name]; !ok {
+			return fmt.Errorf("%w: %q is not understood by this recipient", ErrUnsupportedCritHeader, name)
+		}
+	}
+
+	// Every understood critical extension must also actually be present in the header.
+	return CheckCrit(data, crit)
 }

--- a/crit.go
+++ b/crit.go
@@ -60,10 +60,13 @@ func CheckCrit(data json.RawMessage, crit []string) error {
 // invalid unless every listed critical extension is understood by the recipient AND present in the
 // header. understood is the set of extension names the recipient is configured to process; any crit
 // entry outside it — or one naming a registered JOSE parameter — is rejected. data is the decoded
-// header (the same JSON object CheckCrit inspects for presence).
+// header (the same JSON object CheckCrit inspects for presence). A present but empty crit list is
+// itself invalid, so callers pass crit only when the member is present.
 func CheckCritUnderstood(data json.RawMessage, crit, understood []string) error {
+	// A present "crit" list must not be empty (RFC 7515 §4.1.11); the caller invokes this only when
+	// the member is present, so an empty slice here is the forbidden "crit":[] case.
 	if len(crit) == 0 {
-		return nil
+		return fmt.Errorf("%w: crit list must not be empty", ErrUnsupportedCritHeader)
 	}
 
 	understoodSet := make(map[string]struct{}, len(understood))

--- a/crit_test.go
+++ b/crit_test.go
@@ -1,6 +1,7 @@
 package jwt_test
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"testing"
 
@@ -28,9 +29,10 @@ func TestCheckCritUnderstood(t *testing.T) {
 			understood: []string{"foo"},
 		},
 		{
-			name: "EmptyCritPasses",
-			data: json.RawMessage(`{}`),
-			crit: nil,
+			name:      "EmptyCritRejected",
+			data:      json.RawMessage(`{}`),
+			crit:      []string{},
+			expectErr: jwt.ErrUnsupportedCritHeader,
 		},
 		{
 			name:       "NotUnderstood",
@@ -97,5 +99,32 @@ func TestRecipientCrit(t *testing.T) {
 
 		var claims map[string]any
 		require.NoError(t, recipient.Consume(t.Context(), token, &claims))
+	})
+}
+
+func TestRecipientMalformedHeader(t *testing.T) {
+	t.Parallel()
+
+	payload := base64.RawURLEncoding.EncodeToString([]byte(`{"sub":"x"}`))
+	recipient := jwt.NewRecipient(jwt.RecipientConfig{})
+
+	t.Run("NullHeader", func(t *testing.T) {
+		t.Parallel()
+
+		// A header of JSON null unmarshals to a nil pointer; Consume must reject it, not panic.
+		token := base64.RawURLEncoding.EncodeToString([]byte("null")) + "." + payload
+
+		var claims map[string]any
+		require.Error(t, recipient.Consume(t.Context(), token, &claims))
+	})
+
+	t.Run("EmptyCrit", func(t *testing.T) {
+		t.Parallel()
+
+		// A present-but-empty crit list is invalid per RFC 7515 §4.1.11.
+		token := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none","crit":[]}`)) + "." + payload
+
+		var claims map[string]any
+		require.ErrorIs(t, recipient.Consume(t.Context(), token, &claims), jwt.ErrUnsupportedCritHeader)
 	})
 }

--- a/crit_test.go
+++ b/crit_test.go
@@ -1,0 +1,101 @@
+package jwt_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/a-novel-kit/jwt"
+)
+
+func TestCheckCritUnderstood(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+
+		data       json.RawMessage
+		crit       []string
+		understood []string
+
+		expectErr error
+	}{
+		{
+			name:       "OK",
+			data:       json.RawMessage(`{"foo":"bar"}`),
+			crit:       []string{"foo"},
+			understood: []string{"foo"},
+		},
+		{
+			name: "EmptyCritPasses",
+			data: json.RawMessage(`{}`),
+			crit: nil,
+		},
+		{
+			name:       "NotUnderstood",
+			data:       json.RawMessage(`{"foo":"bar"}`),
+			crit:       []string{"foo"},
+			understood: nil,
+			expectErr:  jwt.ErrUnsupportedCritHeader,
+		},
+		{
+			name:       "ReservedParam",
+			data:       json.RawMessage(`{"alg":"none"}`),
+			crit:       []string{"alg"},
+			understood: []string{"alg"},
+			expectErr:  jwt.ErrUnsupportedCritHeader,
+		},
+		{
+			name:       "UnderstoodButAbsent",
+			data:       json.RawMessage(`{}`),
+			crit:       []string{"foo"},
+			understood: []string{"foo"},
+			expectErr:  jwt.ErrMissingCritHeader,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := jwt.CheckCritUnderstood(testCase.data, testCase.crit, testCase.understood)
+
+			if testCase.expectErr != nil {
+				require.ErrorIs(t, err, testCase.expectErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestRecipientCrit(t *testing.T) {
+	t.Parallel()
+
+	producer := jwt.NewProducer(jwt.ProducerConfig{
+		Header: jwt.HeaderProducerConfig{Crit: []string{"foo"}},
+	})
+
+	token, err := producer.Issue(t.Context(), map[string]any{"sub": "x"}, map[string]any{"foo": "bar"})
+	require.NoError(t, err)
+
+	t.Run("RejectedByDefault", func(t *testing.T) {
+		t.Parallel()
+
+		// No CriticalHeaders configured: a token that marks "foo" critical must be rejected.
+		recipient := jwt.NewRecipient(jwt.RecipientConfig{})
+
+		var claims map[string]any
+		require.ErrorIs(t, recipient.Consume(t.Context(), token, &claims), jwt.ErrUnsupportedCritHeader)
+	})
+
+	t.Run("AcceptedWhenUnderstood", func(t *testing.T) {
+		t.Parallel()
+
+		recipient := jwt.NewRecipient(jwt.RecipientConfig{CriticalHeaders: []string{"foo"}})
+
+		var claims map[string]any
+		require.NoError(t, recipient.Consume(t.Context(), token, &claims))
+	})
+}

--- a/crit_test.go
+++ b/crit_test.go
@@ -115,7 +115,7 @@ func TestRecipientMalformedHeader(t *testing.T) {
 		token := base64.RawURLEncoding.EncodeToString([]byte("null")) + "." + payload
 
 		var claims map[string]any
-		require.Error(t, recipient.Consume(t.Context(), token, &claims))
+		require.ErrorIs(t, recipient.Consume(t.Context(), token, &claims), jwt.ErrUnsupportedTokenFormat)
 	})
 
 	t.Run("EmptyCrit", func(t *testing.T) {

--- a/recipient.go
+++ b/recipient.go
@@ -30,6 +30,10 @@ type RecipientConfig struct {
 
 	// MaxTokenBytes rejects tokens larger than this before parsing. Non-positive selects DefaultMaxTokenBytes.
 	MaxTokenBytes int
+
+	// CriticalHeaders names the "crit" extensions this recipient understands and will process. A
+	// token whose crit list names anything outside this set is rejected (RFC 7515 §4.1.11).
+	CriticalHeaders []string
 }
 
 // A Recipient verifies and decodes JWTs against a fixed set of plugins.
@@ -88,7 +92,7 @@ func (recipient *Recipient) Consume(ctx context.Context, rawToken string, dst an
 	}
 
 	if len(header.Crit) > 0 {
-		err = CheckCrit(decodedHeader, header.Crit)
+		err = CheckCritUnderstood(decodedHeader, header.Crit, recipient.config.CriticalHeaders)
 		if err != nil {
 			return fmt.Errorf("(Recipient.Consume) check crit: %w", err)
 		}

--- a/recipient.go
+++ b/recipient.go
@@ -91,7 +91,15 @@ func (recipient *Recipient) Consume(ctx context.Context, rawToken string, dst an
 		return fmt.Errorf("(Recipient.Consume) unmarshal header: %w", err)
 	}
 
-	if len(header.Crit) > 0 {
+	// A header segment of JSON "null" unmarshals into a nil pointer without error; reject it before
+	// dereferencing rather than panicking on untrusted input.
+	if header == nil {
+		return fmt.Errorf("(Recipient.Consume) %w: null header", ErrUnsupportedTokenFormat)
+	}
+
+	// A non-nil Crit means the "crit" member is present in the header. Whether it is well-formed —
+	// including the RFC 7515 §4.1.11 rule that it must not be empty — is CheckCritUnderstood's call.
+	if header.Crit != nil {
 		err = CheckCritUnderstood(decodedHeader, header.Crit, recipient.config.CriticalHeaders)
 		if err != nil {
 			return fmt.Errorf("(Recipient.Consume) check crit: %w", err)


### PR DESCRIPTION
## Summary

Task #420 of Epic #430. Fixes the `crit` handling, which inverted RFC 7515 §4.1.11: `CheckCrit` only checked that each critical parameter was *present*, never that the recipient *understood* it — so a token could mark any parameter critical and pass.

- **`CheckCritUnderstood(data, crit, understood)`** enforces the recipient obligation: every crit entry must be in the recipient's understood set **and** present in the header, and must not name a reserved JOSE parameter (`alg`, `enc`, …, `crit`).
- **`RecipientConfig.CriticalHeaders`** is the registry — the extensions this recipient will process. **Empty by default**, so a `crit` token is rejected unless the app opts in. Actively-exploited class (PyJWT CVE-2026-32597, Authlib CVE-2025-59420).

The producer-side `CheckCrit` (verifies declared crit params are present) is unchanged.

## Compatibility

Additive API (`CriticalHeaders`, `CheckCritUnderstood`, `ErrUnsupportedCritHeader`) → non-breaking. **Behaviour change:** recipients now reject `crit` tokens unless the extension is registered — the RFC-correct default. We use no `crit`, so no internal impact; ships in v1.3.0 with a changelog note.

## Test plan

- [x] `go test ./...` passes.
- [x] New tests: understood/not-understood/reserved/absent for `CheckCritUnderstood`; recipient rejects a crit token by default and accepts it once the extension is registered.

Closes #420