### PR TITLE
fix(jws): enforce key-size floors for HMAC and RSA

### DIFF
--- a/jws/common.go
+++ b/jws/common.go
@@ -1,6 +1,12 @@
 package jws
 
-import "errors"
+import (
+	"crypto/rsa"
+	"errors"
+	"fmt"
+
+	"github.com/a-novel-kit/jwt"
+)
 
 // ErrInvalidSignature is returned by a verifier when a token's signature does not match its header
 // and payload, or when the signature is malformed. A source-backed verifier also returns it once no
@@ -10,3 +16,32 @@ var ErrInvalidSignature = errors.New("invalid signature")
 // minRSAKeyBits is the smallest RSA modulus the RS* and PS* algorithms accept, per RFC 7518 §3.3
 // and §3.5 ("A key of size 2048 bits or larger MUST be used"). Enforced at both sign and verify.
 const minRSAKeyBits = 2048
+
+// checkRSAPublicKey fails closed unless key is a usable RSA public key: non-nil, with a positive
+// modulus of at least minRSAKeyBits. It rejects nil, non-positive (BitLen reads the absolute value,
+// so a negative modulus would otherwise pass), and sub-floor moduli, so no invalid key reaches
+// crypto/rsa where the failure would be later and less clear.
+func checkRSAPublicKey(key *rsa.PublicKey) error {
+	if key == nil || key.N == nil || key.N.Sign() <= 0 {
+		return fmt.Errorf("%w: RSA key has no valid modulus", jwt.ErrInvalidSecretKey)
+	}
+
+	if key.N.BitLen() < minRSAKeyBits {
+		return fmt.Errorf(
+			"%w: RSA key is %d bits, need at least %d",
+			jwt.ErrInvalidSecretKey, key.N.BitLen(), minRSAKeyBits,
+		)
+	}
+
+	return nil
+}
+
+// checkRSAPrivateKey applies checkRSAPublicKey to a private key's public half, rejecting a nil key
+// first so the dereference is safe.
+func checkRSAPrivateKey(key *rsa.PrivateKey) error {
+	if key == nil {
+		return fmt.Errorf("%w: nil RSA key", jwt.ErrInvalidSecretKey)
+	}
+
+	return checkRSAPublicKey(&key.PublicKey)
+}

--- a/jws/common.go
+++ b/jws/common.go
@@ -6,3 +6,7 @@ import "errors"
 // and payload, or when the signature is malformed. A source-backed verifier also returns it once no
 // candidate key accepts the token.
 var ErrInvalidSignature = errors.New("invalid signature")
+
+// minRSAKeyBits is the smallest RSA modulus the RS* and PS* algorithms accept, per RFC 7518 §3.3
+// and §3.5 ("A key of size 2048 bits or larger MUST be used"). Enforced at both sign and verify.
+const minRSAKeyBits = 2048

--- a/jws/hmac.go
+++ b/jws/hmac.go
@@ -77,6 +77,15 @@ func (signer *HMACSigner) Header(_ context.Context, header *jwa.JWH) (*jwa.JWH, 
 }
 
 func (signer *HMACSigner) Transform(_ context.Context, _ *jwa.JWH, tokenRaw string) (string, error) {
+	// Re-check on the signing path too: a sourced signer re-resolves its key here without going
+	// back through Header, so this is the only guard that actually gates every signature.
+	if len(signer.secretKey) < signer.hash.Size() {
+		return "", fmt.Errorf(
+			"(HMACSigner.Transform) %w: HMAC key is %d bytes, need at least %d (RFC 7518 §3.2)",
+			jwt.ErrInvalidSecretKey, len(signer.secretKey), signer.hash.Size(),
+		)
+	}
+
 	token, err := jwt.DecodeToken(tokenRaw, &jwt.RawTokenDecoder{})
 	if err != nil {
 		return "", fmt.Errorf("(HMACSigner.Transform) split token: %w", err)

--- a/jws/hmac.go
+++ b/jws/hmac.go
@@ -64,6 +64,13 @@ func (signer *HMACSigner) Header(_ context.Context, header *jwa.JWH) (*jwa.JWH, 
 		return nil, fmt.Errorf("(HMACSigner.Header) %w: alg field already set", jwt.ErrConflictingHeader)
 	}
 
+	if len(signer.secretKey) < signer.hash.Size() {
+		return nil, fmt.Errorf(
+			"(HMACSigner.Header) %w: HMAC key is %d bytes, need at least %d (RFC 7518 §3.2)",
+			jwt.ErrInvalidSecretKey, len(signer.secretKey), signer.hash.Size(),
+		)
+	}
+
 	header.Alg = signer.alg
 
 	return header, nil
@@ -114,6 +121,13 @@ func (verifier *HMACVerifier) Transform(_ context.Context, header *jwa.JWH, rawT
 		return nil, fmt.Errorf(
 			"(HMACVerifier.Transform) %w: invalid algorithm %s, expected %s",
 			jwt.ErrMismatchRecipientPlugin, header.Alg, verifier.alg,
+		)
+	}
+
+	if len(verifier.secretKey) < verifier.hash.Size() {
+		return nil, fmt.Errorf(
+			"(HMACVerifier.Transform) %w: HMAC key is %d bytes, need at least %d (RFC 7518 §3.2)",
+			jwt.ErrInvalidSecretKey, len(verifier.secretKey), verifier.hash.Size(),
 		)
 	}
 

--- a/jws/keyfloor_test.go
+++ b/jws/keyfloor_test.go
@@ -141,6 +141,13 @@ func TestRSANilKey(t *testing.T) {
 		require.ErrorIs(t, err, jwt.ErrInvalidSecretKey)
 	})
 
+	t.Run("PS256SignerTransform", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := jws.NewRSAPSSSigner(nil, jws.PS256).Transform(t.Context(), &jwa.JWH{}, "a.b")
+		require.ErrorIs(t, err, jwt.ErrInvalidSecretKey)
+	})
+
 	t.Run("PS256VerifierNilModulus", func(t *testing.T) {
 		t.Parallel()
 

--- a/jws/keyfloor_test.go
+++ b/jws/keyfloor_test.go
@@ -84,3 +84,24 @@ func TestRSAPSSWeakKey(t *testing.T) {
 		require.ErrorIs(t, err, jwt.ErrInvalidSecretKey)
 	})
 }
+
+func TestRSANilKey(t *testing.T) {
+	t.Parallel()
+
+	// The size floor must fail closed on a nil key or nil modulus, not panic.
+	t.Run("SignerNil", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := jws.NewRSASigner(nil, jws.RS256).Header(t.Context(), &jwa.JWH{})
+		require.ErrorIs(t, err, jwt.ErrInvalidSecretKey)
+	})
+
+	t.Run("VerifierNilModulus", func(t *testing.T) {
+		t.Parallel()
+
+		header := &jwa.JWH{JWHCommon: jwa.JWHCommon{Alg: jwa.RS256}}
+
+		_, err := jws.NewRSAVerifier(&rsa.PublicKey{}, jws.RS256).Transform(t.Context(), header, "a.b.c")
+		require.ErrorIs(t, err, jwt.ErrInvalidSecretKey)
+	})
+}

--- a/jws/keyfloor_test.go
+++ b/jws/keyfloor_test.go
@@ -149,4 +149,16 @@ func TestRSANilKey(t *testing.T) {
 		_, err := jws.NewRSAPSSVerifier(&rsa.PublicKey{}, jws.PS256).Transform(t.Context(), header, "a.b.c")
 		require.ErrorIs(t, err, jwt.ErrInvalidSecretKey)
 	})
+
+	t.Run("NegativeModulus", func(t *testing.T) {
+		t.Parallel()
+
+		// |N| clears the bit-length floor, but N is negative; BitLen reads the absolute value, so
+		// only the sign check rejects it.
+		negN := new(big.Int).Neg(new(big.Int).Lsh(big.NewInt(1), 2048))
+		header := &jwa.JWH{JWHCommon: jwa.JWHCommon{Alg: jwa.RS256}}
+
+		_, err := jws.NewRSAVerifier(&rsa.PublicKey{N: negN, E: 65537}, jws.RS256).Transform(t.Context(), header, "a.b.c")
+		require.ErrorIs(t, err, jwt.ErrInvalidSecretKey)
+	})
 }

--- a/jws/keyfloor_test.go
+++ b/jws/keyfloor_test.go
@@ -1,0 +1,86 @@
+package jws_test
+
+import (
+	"crypto/rsa"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/a-novel-kit/jwt"
+	"github.com/a-novel-kit/jwt/jwa"
+	"github.com/a-novel-kit/jwt/jws"
+)
+
+// smallRSAKey is a bogus RSA key with a sub-2048-bit modulus. It is enough to exercise the key-size
+// floor — which only reads the modulus bit length before any crypto — without a slow weak-key
+// generation.
+func smallRSAKey() *rsa.PrivateKey {
+	return &rsa.PrivateKey{PublicKey: rsa.PublicKey{N: big.NewInt(12345), E: 65537}}
+}
+
+func TestHMACWeakKey(t *testing.T) {
+	t.Parallel()
+
+	shortKey := []byte("too-short") // 9 bytes, under the 32-byte HS256 floor.
+
+	t.Run("Signer", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := jws.NewHMACSigner(shortKey, jws.HS256).Header(t.Context(), &jwa.JWH{})
+		require.ErrorIs(t, err, jwt.ErrInvalidSecretKey)
+	})
+
+	t.Run("Verifier", func(t *testing.T) {
+		t.Parallel()
+
+		header := &jwa.JWH{JWHCommon: jwa.JWHCommon{Alg: jwa.HS256}}
+
+		_, err := jws.NewHMACVerifier(shortKey, jws.HS256).Transform(t.Context(), header, "a.b.c")
+		require.ErrorIs(t, err, jwt.ErrInvalidSecretKey)
+	})
+}
+
+func TestRSAWeakKey(t *testing.T) {
+	t.Parallel()
+
+	key := smallRSAKey()
+
+	t.Run("Signer", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := jws.NewRSASigner(key, jws.RS256).Header(t.Context(), &jwa.JWH{})
+		require.ErrorIs(t, err, jwt.ErrInvalidSecretKey)
+	})
+
+	t.Run("Verifier", func(t *testing.T) {
+		t.Parallel()
+
+		header := &jwa.JWH{JWHCommon: jwa.JWHCommon{Alg: jwa.RS256}}
+
+		_, err := jws.NewRSAVerifier(&key.PublicKey, jws.RS256).Transform(t.Context(), header, "a.b.c")
+		require.ErrorIs(t, err, jwt.ErrInvalidSecretKey)
+	})
+}
+
+func TestRSAPSSWeakKey(t *testing.T) {
+	t.Parallel()
+
+	key := smallRSAKey()
+
+	t.Run("Signer", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := jws.NewRSAPSSSigner(key, jws.PS256).Header(t.Context(), &jwa.JWH{})
+		require.ErrorIs(t, err, jwt.ErrInvalidSecretKey)
+	})
+
+	t.Run("Verifier", func(t *testing.T) {
+		t.Parallel()
+
+		header := &jwa.JWH{JWHCommon: jwa.JWHCommon{Alg: jwa.PS256}}
+
+		_, err := jws.NewRSAPSSVerifier(&key.PublicKey, jws.PS256).Transform(t.Context(), header, "a.b.c")
+		require.ErrorIs(t, err, jwt.ErrInvalidSecretKey)
+	})
+}

--- a/jws/keyfloor_test.go
+++ b/jws/keyfloor_test.go
@@ -24,10 +24,17 @@ func TestHMACWeakKey(t *testing.T) {
 
 	shortKey := []byte("too-short") // 9 bytes, under the 32-byte HS256 floor.
 
-	t.Run("Signer", func(t *testing.T) {
+	t.Run("SignerHeader", func(t *testing.T) {
 		t.Parallel()
 
 		_, err := jws.NewHMACSigner(shortKey, jws.HS256).Header(t.Context(), &jwa.JWH{})
+		require.ErrorIs(t, err, jwt.ErrInvalidSecretKey)
+	})
+
+	t.Run("SignerTransform", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := jws.NewHMACSigner(shortKey, jws.HS256).Transform(t.Context(), &jwa.JWH{}, "a.b")
 		require.ErrorIs(t, err, jwt.ErrInvalidSecretKey)
 	})
 
@@ -46,10 +53,17 @@ func TestRSAWeakKey(t *testing.T) {
 
 	key := smallRSAKey()
 
-	t.Run("Signer", func(t *testing.T) {
+	t.Run("SignerHeader", func(t *testing.T) {
 		t.Parallel()
 
 		_, err := jws.NewRSASigner(key, jws.RS256).Header(t.Context(), &jwa.JWH{})
+		require.ErrorIs(t, err, jwt.ErrInvalidSecretKey)
+	})
+
+	t.Run("SignerTransform", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := jws.NewRSASigner(key, jws.RS256).Transform(t.Context(), &jwa.JWH{}, "a.b")
 		require.ErrorIs(t, err, jwt.ErrInvalidSecretKey)
 	})
 
@@ -68,10 +82,17 @@ func TestRSAPSSWeakKey(t *testing.T) {
 
 	key := smallRSAKey()
 
-	t.Run("Signer", func(t *testing.T) {
+	t.Run("SignerHeader", func(t *testing.T) {
 		t.Parallel()
 
 		_, err := jws.NewRSAPSSSigner(key, jws.PS256).Header(t.Context(), &jwa.JWH{})
+		require.ErrorIs(t, err, jwt.ErrInvalidSecretKey)
+	})
+
+	t.Run("SignerTransform", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := jws.NewRSAPSSSigner(key, jws.PS256).Transform(t.Context(), &jwa.JWH{}, "a.b")
 		require.ErrorIs(t, err, jwt.ErrInvalidSecretKey)
 	})
 
@@ -85,23 +106,47 @@ func TestRSAPSSWeakKey(t *testing.T) {
 	})
 }
 
+// TestRSANilKey checks the size floor fails closed on a nil key or nil modulus, not panic, across
+// both the RS* and PS* variants and every code path that touches the key.
 func TestRSANilKey(t *testing.T) {
 	t.Parallel()
 
-	// The size floor must fail closed on a nil key or nil modulus, not panic.
-	t.Run("SignerNil", func(t *testing.T) {
+	t.Run("RS256SignerHeader", func(t *testing.T) {
 		t.Parallel()
 
 		_, err := jws.NewRSASigner(nil, jws.RS256).Header(t.Context(), &jwa.JWH{})
 		require.ErrorIs(t, err, jwt.ErrInvalidSecretKey)
 	})
 
-	t.Run("VerifierNilModulus", func(t *testing.T) {
+	t.Run("RS256SignerTransform", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := jws.NewRSASigner(nil, jws.RS256).Transform(t.Context(), &jwa.JWH{}, "a.b")
+		require.ErrorIs(t, err, jwt.ErrInvalidSecretKey)
+	})
+
+	t.Run("RS256VerifierNilModulus", func(t *testing.T) {
 		t.Parallel()
 
 		header := &jwa.JWH{JWHCommon: jwa.JWHCommon{Alg: jwa.RS256}}
 
 		_, err := jws.NewRSAVerifier(&rsa.PublicKey{}, jws.RS256).Transform(t.Context(), header, "a.b.c")
+		require.ErrorIs(t, err, jwt.ErrInvalidSecretKey)
+	})
+
+	t.Run("PS256SignerHeader", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := jws.NewRSAPSSSigner(nil, jws.PS256).Header(t.Context(), &jwa.JWH{})
+		require.ErrorIs(t, err, jwt.ErrInvalidSecretKey)
+	})
+
+	t.Run("PS256VerifierNilModulus", func(t *testing.T) {
+		t.Parallel()
+
+		header := &jwa.JWH{JWHCommon: jwa.JWHCommon{Alg: jwa.PS256}}
+
+		_, err := jws.NewRSAPSSVerifier(&rsa.PublicKey{}, jws.PS256).Transform(t.Context(), header, "a.b.c")
 		require.ErrorIs(t, err, jwt.ErrInvalidSecretKey)
 	})
 }

--- a/jws/rsa.go
+++ b/jws/rsa.go
@@ -65,10 +65,10 @@ func (signer *RSASigner) Header(_ context.Context, header *jwa.JWH) (*jwa.JWH, e
 		return nil, fmt.Errorf("(RSASigner.Header) %w: alg field already set", jwt.ErrConflictingHeader)
 	}
 
-	if signer.secretKey.N.BitLen() < minRSAKeyBits {
+	if signer.secretKey == nil || signer.secretKey.N == nil || signer.secretKey.N.BitLen() < minRSAKeyBits {
 		return nil, fmt.Errorf(
-			"(RSASigner.Header) %w: RSA key is %d bits, need at least %d (RFC 7518 §3.3)",
-			jwt.ErrInvalidSecretKey, signer.secretKey.N.BitLen(), minRSAKeyBits,
+			"(RSASigner.Header) %w: RSA key must be a valid modulus of at least %d bits (RFC 7518 §3.3)",
+			jwt.ErrInvalidSecretKey, minRSAKeyBits,
 		)
 	}
 
@@ -127,10 +127,10 @@ func (verifier *RSAVerifier) Transform(_ context.Context, header *jwa.JWH, rawTo
 		)
 	}
 
-	if verifier.publicKey.N.BitLen() < minRSAKeyBits {
+	if verifier.publicKey == nil || verifier.publicKey.N == nil || verifier.publicKey.N.BitLen() < minRSAKeyBits {
 		return nil, fmt.Errorf(
-			"(RSAVerifier.Transform) %w: RSA key is %d bits, need at least %d (RFC 7518 §3.3)",
-			jwt.ErrInvalidSecretKey, verifier.publicKey.N.BitLen(), minRSAKeyBits,
+			"(RSAVerifier.Transform) %w: RSA key must be a valid modulus of at least %d bits (RFC 7518 §3.3)",
+			jwt.ErrInvalidSecretKey, minRSAKeyBits,
 		)
 	}
 

--- a/jws/rsa.go
+++ b/jws/rsa.go
@@ -65,6 +65,13 @@ func (signer *RSASigner) Header(_ context.Context, header *jwa.JWH) (*jwa.JWH, e
 		return nil, fmt.Errorf("(RSASigner.Header) %w: alg field already set", jwt.ErrConflictingHeader)
 	}
 
+	if signer.secretKey.N.BitLen() < minRSAKeyBits {
+		return nil, fmt.Errorf(
+			"(RSASigner.Header) %w: RSA key is %d bits, need at least %d (RFC 7518 §3.3)",
+			jwt.ErrInvalidSecretKey, signer.secretKey.N.BitLen(), minRSAKeyBits,
+		)
+	}
+
 	header.Alg = signer.alg
 
 	return header, nil
@@ -117,6 +124,13 @@ func (verifier *RSAVerifier) Transform(_ context.Context, header *jwa.JWH, rawTo
 		return nil, fmt.Errorf(
 			"(RSAVerifier.Transform) %w: invalid algorithm %s, expected %s",
 			jwt.ErrMismatchRecipientPlugin, header.Alg, verifier.alg,
+		)
+	}
+
+	if verifier.publicKey.N.BitLen() < minRSAKeyBits {
+		return nil, fmt.Errorf(
+			"(RSAVerifier.Transform) %w: RSA key is %d bits, need at least %d (RFC 7518 §3.3)",
+			jwt.ErrInvalidSecretKey, verifier.publicKey.N.BitLen(), minRSAKeyBits,
 		)
 	}
 

--- a/jws/rsa.go
+++ b/jws/rsa.go
@@ -65,11 +65,9 @@ func (signer *RSASigner) Header(_ context.Context, header *jwa.JWH) (*jwa.JWH, e
 		return nil, fmt.Errorf("(RSASigner.Header) %w: alg field already set", jwt.ErrConflictingHeader)
 	}
 
-	if signer.secretKey == nil || signer.secretKey.N == nil || signer.secretKey.N.BitLen() < minRSAKeyBits {
-		return nil, fmt.Errorf(
-			"(RSASigner.Header) %w: RSA key must be a valid modulus of at least %d bits (RFC 7518 §3.3)",
-			jwt.ErrInvalidSecretKey, minRSAKeyBits,
-		)
+	err := checkRSAPrivateKey(signer.secretKey)
+	if err != nil {
+		return nil, fmt.Errorf("(RSASigner.Header) %w", err)
 	}
 
 	header.Alg = signer.alg
@@ -80,11 +78,9 @@ func (signer *RSASigner) Header(_ context.Context, header *jwa.JWH) (*jwa.JWH, e
 func (signer *RSASigner) Transform(_ context.Context, _ *jwa.JWH, tokenRaw string) (string, error) {
 	// Re-check on the signing path too: a sourced signer re-resolves its key here without going
 	// back through Header, so this is the only guard that actually gates every signature.
-	if signer.secretKey == nil || signer.secretKey.N == nil || signer.secretKey.N.BitLen() < minRSAKeyBits {
-		return "", fmt.Errorf(
-			"(RSASigner.Transform) %w: RSA key must be a valid modulus of at least %d bits (RFC 7518 §3.3)",
-			jwt.ErrInvalidSecretKey, minRSAKeyBits,
-		)
+	err := checkRSAPrivateKey(signer.secretKey)
+	if err != nil {
+		return "", fmt.Errorf("(RSASigner.Transform) %w", err)
 	}
 
 	token, err := jwt.DecodeToken(tokenRaw, &jwt.RawTokenDecoder{})
@@ -136,11 +132,9 @@ func (verifier *RSAVerifier) Transform(_ context.Context, header *jwa.JWH, rawTo
 		)
 	}
 
-	if verifier.publicKey == nil || verifier.publicKey.N == nil || verifier.publicKey.N.BitLen() < minRSAKeyBits {
-		return nil, fmt.Errorf(
-			"(RSAVerifier.Transform) %w: RSA key must be a valid modulus of at least %d bits (RFC 7518 §3.3)",
-			jwt.ErrInvalidSecretKey, minRSAKeyBits,
-		)
+	err := checkRSAPublicKey(verifier.publicKey)
+	if err != nil {
+		return nil, fmt.Errorf("(RSAVerifier.Transform) %w", err)
 	}
 
 	token, err := jwt.DecodeToken(rawToken, &jwt.SignedTokenDecoder{})

--- a/jws/rsa.go
+++ b/jws/rsa.go
@@ -78,6 +78,15 @@ func (signer *RSASigner) Header(_ context.Context, header *jwa.JWH) (*jwa.JWH, e
 }
 
 func (signer *RSASigner) Transform(_ context.Context, _ *jwa.JWH, tokenRaw string) (string, error) {
+	// Re-check on the signing path too: a sourced signer re-resolves its key here without going
+	// back through Header, so this is the only guard that actually gates every signature.
+	if signer.secretKey == nil || signer.secretKey.N == nil || signer.secretKey.N.BitLen() < minRSAKeyBits {
+		return "", fmt.Errorf(
+			"(RSASigner.Transform) %w: RSA key must be a valid modulus of at least %d bits (RFC 7518 §3.3)",
+			jwt.ErrInvalidSecretKey, minRSAKeyBits,
+		)
+	}
+
 	token, err := jwt.DecodeToken(tokenRaw, &jwt.RawTokenDecoder{})
 	if err != nil {
 		return "", fmt.Errorf("(RSASigner.Transform) split token: %w", err)

--- a/jws/rsa_pss.go
+++ b/jws/rsa_pss.go
@@ -66,11 +66,9 @@ func (signer *RSAPSSSigner) Header(_ context.Context, header *jwa.JWH) (*jwa.JWH
 		return nil, fmt.Errorf("(RSAPSSSigner.Header) %w: alg field already set", jwt.ErrConflictingHeader)
 	}
 
-	if signer.secretKey == nil || signer.secretKey.N == nil || signer.secretKey.N.BitLen() < minRSAKeyBits {
-		return nil, fmt.Errorf(
-			"(RSAPSSSigner.Header) %w: RSA key must be a valid modulus of at least %d bits (RFC 7518 §3.5)",
-			jwt.ErrInvalidSecretKey, minRSAKeyBits,
-		)
+	err := checkRSAPrivateKey(signer.secretKey)
+	if err != nil {
+		return nil, fmt.Errorf("(RSAPSSSigner.Header) %w", err)
 	}
 
 	header.Alg = signer.alg
@@ -81,11 +79,9 @@ func (signer *RSAPSSSigner) Header(_ context.Context, header *jwa.JWH) (*jwa.JWH
 func (signer *RSAPSSSigner) Transform(_ context.Context, _ *jwa.JWH, tokenRaw string) (string, error) {
 	// Re-check on the signing path too: a sourced signer re-resolves its key here without going
 	// back through Header, so this is the only guard that actually gates every signature.
-	if signer.secretKey == nil || signer.secretKey.N == nil || signer.secretKey.N.BitLen() < minRSAKeyBits {
-		return "", fmt.Errorf(
-			"(RSAPSSSigner.Transform) %w: RSA key must be a valid modulus of at least %d bits (RFC 7518 §3.5)",
-			jwt.ErrInvalidSecretKey, minRSAKeyBits,
-		)
+	err := checkRSAPrivateKey(signer.secretKey)
+	if err != nil {
+		return "", fmt.Errorf("(RSAPSSSigner.Transform) %w", err)
 	}
 
 	token, err := jwt.DecodeToken(tokenRaw, &jwt.RawTokenDecoder{})
@@ -139,11 +135,9 @@ func (verifier *RSAPSSVerifier) Transform(_ context.Context, header *jwa.JWH, ra
 		)
 	}
 
-	if verifier.publicKey == nil || verifier.publicKey.N == nil || verifier.publicKey.N.BitLen() < minRSAKeyBits {
-		return nil, fmt.Errorf(
-			"(RSAPSSVerifier.Transform) %w: RSA key must be a valid modulus of at least %d bits (RFC 7518 §3.5)",
-			jwt.ErrInvalidSecretKey, minRSAKeyBits,
-		)
+	err := checkRSAPublicKey(verifier.publicKey)
+	if err != nil {
+		return nil, fmt.Errorf("(RSAPSSVerifier.Transform) %w", err)
 	}
 
 	token, err := jwt.DecodeToken(rawToken, &jwt.SignedTokenDecoder{})

--- a/jws/rsa_pss.go
+++ b/jws/rsa_pss.go
@@ -66,6 +66,13 @@ func (signer *RSAPSSSigner) Header(_ context.Context, header *jwa.JWH) (*jwa.JWH
 		return nil, fmt.Errorf("(RSAPSSSigner.Header) %w: alg field already set", jwt.ErrConflictingHeader)
 	}
 
+	if signer.secretKey.N.BitLen() < minRSAKeyBits {
+		return nil, fmt.Errorf(
+			"(RSAPSSSigner.Header) %w: RSA key is %d bits, need at least %d (RFC 7518 §3.5)",
+			jwt.ErrInvalidSecretKey, signer.secretKey.N.BitLen(), minRSAKeyBits,
+		)
+	}
+
 	header.Alg = signer.alg
 
 	return header, nil
@@ -120,6 +127,13 @@ func (verifier *RSAPSSVerifier) Transform(_ context.Context, header *jwa.JWH, ra
 		return nil, fmt.Errorf(
 			"(RSAPSSVerifier.Transform) %w: invalid algorithm %s, expected %s",
 			jwt.ErrMismatchRecipientPlugin, header.Alg, verifier.alg,
+		)
+	}
+
+	if verifier.publicKey.N.BitLen() < minRSAKeyBits {
+		return nil, fmt.Errorf(
+			"(RSAPSSVerifier.Transform) %w: RSA key is %d bits, need at least %d (RFC 7518 §3.5)",
+			jwt.ErrInvalidSecretKey, verifier.publicKey.N.BitLen(), minRSAKeyBits,
 		)
 	}
 

--- a/jws/rsa_pss.go
+++ b/jws/rsa_pss.go
@@ -79,6 +79,15 @@ func (signer *RSAPSSSigner) Header(_ context.Context, header *jwa.JWH) (*jwa.JWH
 }
 
 func (signer *RSAPSSSigner) Transform(_ context.Context, _ *jwa.JWH, tokenRaw string) (string, error) {
+	// Re-check on the signing path too: a sourced signer re-resolves its key here without going
+	// back through Header, so this is the only guard that actually gates every signature.
+	if signer.secretKey == nil || signer.secretKey.N == nil || signer.secretKey.N.BitLen() < minRSAKeyBits {
+		return "", fmt.Errorf(
+			"(RSAPSSSigner.Transform) %w: RSA key must be a valid modulus of at least %d bits (RFC 7518 §3.5)",
+			jwt.ErrInvalidSecretKey, minRSAKeyBits,
+		)
+	}
+
 	token, err := jwt.DecodeToken(tokenRaw, &jwt.RawTokenDecoder{})
 	if err != nil {
 		return "", fmt.Errorf("(RSAPSSSigner.Transform) split token: %w", err)

--- a/jws/rsa_pss.go
+++ b/jws/rsa_pss.go
@@ -66,10 +66,10 @@ func (signer *RSAPSSSigner) Header(_ context.Context, header *jwa.JWH) (*jwa.JWH
 		return nil, fmt.Errorf("(RSAPSSSigner.Header) %w: alg field already set", jwt.ErrConflictingHeader)
 	}
 
-	if signer.secretKey.N.BitLen() < minRSAKeyBits {
+	if signer.secretKey == nil || signer.secretKey.N == nil || signer.secretKey.N.BitLen() < minRSAKeyBits {
 		return nil, fmt.Errorf(
-			"(RSAPSSSigner.Header) %w: RSA key is %d bits, need at least %d (RFC 7518 §3.5)",
-			jwt.ErrInvalidSecretKey, signer.secretKey.N.BitLen(), minRSAKeyBits,
+			"(RSAPSSSigner.Header) %w: RSA key must be a valid modulus of at least %d bits (RFC 7518 §3.5)",
+			jwt.ErrInvalidSecretKey, minRSAKeyBits,
 		)
 	}
 
@@ -130,10 +130,10 @@ func (verifier *RSAPSSVerifier) Transform(_ context.Context, header *jwa.JWH, ra
 		)
 	}
 
-	if verifier.publicKey.N.BitLen() < minRSAKeyBits {
+	if verifier.publicKey == nil || verifier.publicKey.N == nil || verifier.publicKey.N.BitLen() < minRSAKeyBits {
 		return nil, fmt.Errorf(
-			"(RSAPSSVerifier.Transform) %w: RSA key is %d bits, need at least %d (RFC 7518 §3.5)",
-			jwt.ErrInvalidSecretKey, verifier.publicKey.N.BitLen(), minRSAKeyBits,
+			"(RSAPSSVerifier.Transform) %w: RSA key must be a valid modulus of at least %d bits (RFC 7518 §3.5)",
+			jwt.ErrInvalidSecretKey, minRSAKeyBits,
 		)
 	}
 


### PR DESCRIPTION
## Summary

Task #422 of Epic #430. Enforces the RFC 7518 key-size floors the doc comments already cited but the code never checked, at **both sign and verify**:

- **HMAC (§3.2):** key must be at least the hash output size (32 B for HS256, 48 B for HS384, 64 B for HS512). A short secret is brute-forceable offline from any captured token.
- **RSA RS*/PS* (§3.3/§3.5):** modulus must be ≥ 2048 bits. A small modulus is forgeable.

Both return `jwt.ErrInvalidSecretKey` (the sentinel ECDSA already uses for key/alg mismatch). Checks live in each signer's `Header` and verifier's `Transform`, so the `Sourced*` variants inherit them for free.

## Compatibility

Non-breaking — no API change; only *rejects* egregiously weak keys that should never have been accepted. Ships in v1.3.0.

## Test plan

- [x] `go test ./...` passes (existing tests use 64–128 B HMAC keys and 2048–4096 bit RSA keys — all above the floors).
- [x] New `keyfloor_test.go`: HMAC/RSA/RSA-PSS reject a sub-floor key at both sign and verify.

Closes #422