### PR TITLE
fix(jwk): negative caching and read-lock fast path for Source

### DIFF
--- a/jwk/source.go
+++ b/jwk/source.go
@@ -46,7 +46,7 @@ type Source[K any] struct {
 
 	cached      []*Key[K]
 	lastCached  time.Time
-	lastAttempt time.Time
+	lastFailure time.Time
 	lastErr     error
 
 	mu *sync.RWMutex
@@ -81,15 +81,16 @@ func (source *Source[K]) refresh(ctx context.Context) error {
 		retry = DefaultRetryInterval
 	}
 
-	if source.lastErr != nil && time.Since(source.lastAttempt) < retry {
+	// Measure the backoff from when a failure is observed, not when the attempt starts: a Fetch that
+	// itself takes longer than retry would otherwise let the next caller re-fetch immediately.
+	if source.lastErr != nil && time.Since(source.lastFailure) < retry {
 		return source.lastErr
 	}
-
-	source.lastAttempt = time.Now()
 
 	keys, err := source.config.Fetch(ctx)
 	if err != nil {
 		source.lastErr = fmt.Errorf("(Source.refresh) fetch keys: %w", err)
+		source.lastFailure = time.Now()
 
 		return source.lastErr
 	}
@@ -100,6 +101,7 @@ func (source *Source[K]) refresh(ctx context.Context) error {
 		parsed, parseErr := source.parser(ctx, key)
 		if parseErr != nil {
 			source.lastErr = fmt.Errorf("(Source.refresh) parse key: %w", parseErr)
+			source.lastFailure = time.Now()
 
 			return source.lastErr
 		}

--- a/jwk/source.go
+++ b/jwk/source.go
@@ -21,12 +21,21 @@ type KeysFetcher func(ctx context.Context) ([]*jwa.JWK, error)
 // KeyParser decodes a raw JSON Web Key into a typed [Key].
 type KeyParser[K any] func(ctx context.Context, jwk *jwa.JWK) (*Key[K], error)
 
+// DefaultRetryInterval bounds how often a [Source] retries a failing Fetch when the config leaves
+// RetryInterval unset, so a broken upstream is not called on every request.
+const DefaultRetryInterval = 30 * time.Second
+
 // SourceConfig configures a [Source].
 type SourceConfig struct {
 	// CacheDuration is how long fetched keys are held before the next fetch.
 	CacheDuration time.Duration
-	// Fetch retrieves the current keys.
+	// Fetch retrieves the current keys. It runs against whatever the caller wires in — often a
+	// remote JWK Set endpoint — so preventing SSRF is the caller's responsibility: pin the host (or
+	// an allowlist), require HTTPS with verified certificates, and set timeouts inside Fetch.
 	Fetch KeysFetcher
+	// RetryInterval bounds how often a failing Fetch is retried (negative caching), so a broken
+	// upstream is not hit on every request. Non-positive selects DefaultRetryInterval.
+	RetryInterval time.Duration
 }
 
 // A Source fetches, caches, and parses the keys used to sign or verify tokens. It refreshes lazily
@@ -35,31 +44,64 @@ type Source[K any] struct {
 	config SourceConfig
 	parser KeyParser[K]
 
-	cached     []*Key[K]
-	lastCached time.Time
+	cached      []*Key[K]
+	lastCached  time.Time
+	lastAttempt time.Time
+	lastErr     error
 
 	mu *sync.RWMutex
 }
 
-func (source *Source[K]) refresh(ctx context.Context) error {
-	source.mu.Lock()
-	defer source.mu.Unlock()
+// fresh reports whether the cache is populated and still within CacheDuration, under a read lock so
+// concurrent readers of a warm cache never serialize behind the write lock.
+func (source *Source[K]) fresh() bool {
+	source.mu.RLock()
+	defer source.mu.RUnlock()
 
-	if time.Since(source.lastCached) < source.config.CacheDuration {
+	return source.cached != nil && time.Since(source.lastCached) < source.config.CacheDuration
+}
+
+func (source *Source[K]) refresh(ctx context.Context) error {
+	if source.fresh() {
 		return nil
 	}
 
+	source.mu.Lock()
+	defer source.mu.Unlock()
+
+	// Another goroutine may have refreshed while we waited for the write lock.
+	if source.cached != nil && time.Since(source.lastCached) < source.config.CacheDuration {
+		return nil
+	}
+
+	// Negative caching: after a failure, don't call Fetch again until RetryInterval has elapsed, so
+	// a broken upstream isn't hit on every request (a thundering-herd / amplification DoS).
+	retry := source.config.RetryInterval
+	if retry <= 0 {
+		retry = DefaultRetryInterval
+	}
+
+	if source.lastErr != nil && time.Since(source.lastAttempt) < retry {
+		return source.lastErr
+	}
+
+	source.lastAttempt = time.Now()
+
 	keys, err := source.config.Fetch(ctx)
 	if err != nil {
-		return fmt.Errorf("(Source.refresh) fetch keys: %w", err)
+		source.lastErr = fmt.Errorf("(Source.refresh) fetch keys: %w", err)
+
+		return source.lastErr
 	}
 
 	parsedKeys := make([]*Key[K], len(keys))
 
 	for i, key := range keys {
-		parsed, err := source.parser(ctx, key)
-		if err != nil {
-			return fmt.Errorf("(Source.refresh) parse key: %w", err)
+		parsed, parseErr := source.parser(ctx, key)
+		if parseErr != nil {
+			source.lastErr = fmt.Errorf("(Source.refresh) parse key: %w", parseErr)
+
+			return source.lastErr
 		}
 
 		parsedKeys[i] = parsed
@@ -67,6 +109,7 @@ func (source *Source[K]) refresh(ctx context.Context) error {
 
 	source.cached = parsedKeys
 	source.lastCached = time.Now()
+	source.lastErr = nil
 
 	return nil
 }

--- a/jwk/source_test.go
+++ b/jwk/source_test.go
@@ -286,3 +286,60 @@ func TestSourceRefresh(t *testing.T) {
 		newBullshitKey[string](t, `"number":4`),
 	}, fetchedKeys)
 }
+
+func TestSourceNegativeCache(t *testing.T) {
+	t.Parallel()
+
+	errFoo := errors.New("foo")
+
+	fetchCount := 0
+	config := jwk.SourceConfig{
+		CacheDuration: time.Hour,
+		RetryInterval: time.Hour,
+		Fetch: func(_ context.Context) ([]*jwa.JWK, error) {
+			fetchCount++
+
+			return nil, errFoo
+		},
+	}
+
+	source := jwk.NewGenericSource[string](config, (&simulateParser[string]{}).parse)
+
+	// Two failing List calls: Fetch must run only once — the second is served from the negative
+	// cache instead of hammering the upstream.
+	_, err := source.List(t.Context())
+	require.ErrorIs(t, err, errFoo)
+
+	_, err = source.List(t.Context())
+	require.ErrorIs(t, err, errFoo)
+
+	require.Equal(t, 1, fetchCount)
+}
+
+func TestSourceCaches(t *testing.T) {
+	t.Parallel()
+
+	fetchCount := 0
+	key := newBullshitKey[string](t, "kid-1")
+	config := jwk.SourceConfig{
+		CacheDuration: time.Hour,
+		Fetch: func(_ context.Context) ([]*jwa.JWK, error) {
+			fetchCount++
+
+			return []*jwa.JWK{key.JWK}, nil
+		},
+	}
+
+	parser := simulateParser[string]{responses: []simulatedParserResp[string]{{key: key}}}
+	source := jwk.NewGenericSource[string](config, parser.parse)
+
+	// A warm cache within CacheDuration serves without a second fetch (nor a second parse, which
+	// would exhaust the one-response parser).
+	_, err := source.List(t.Context())
+	require.NoError(t, err)
+
+	_, err = source.List(t.Context())
+	require.NoError(t, err)
+
+	require.Equal(t, 1, fetchCount)
+}


### PR DESCRIPTION
## Summary

Task #423 of Epic #430. Hardens `jwk.Source`'s cache (S8):

- **Negative caching.** A failed `Fetch` left `lastCached` untouched, so *every* subsequent `List`/`Get` re-hit the upstream — a thundering-herd amplification against the caller's JWKS endpoint. A failure now gates retries by `RetryInterval` (new field, default `DefaultRetryInterval` = 30s).
- **Read-lock fast path.** A warm cache is served under `RLock`, so healthy reads no longer serialize behind the write lock (the write lock is taken only when a refresh is actually needed).
- **SSRF documentation.** The URL/TLS handling lives entirely in the caller's `Fetch`, so the doc now states that host-pinning, HTTPS verification, and timeouts are the caller's responsibility.

Deliberately **not** included: serve-stale-on-outage — it's a real availability/staleness security tradeoff that changes the error contract, so it warrants its own decision.

## Compatibility

Non-breaking — additive `SourceConfig.RetryInterval` and `DefaultRetryInterval`. Existing behaviour (fetch-on-expiry, error-on-first-failure) is preserved.

## Test plan

- [x] `go test ./...` passes (existing cache-expiry test unchanged).
- [x] New tests: a failing `Fetch` runs once across two `List` calls (negative cache); a warm cache serves a second `List` without re-fetching.

Closes #423