### PR TITLE
refactor(jws): shared Sourced-verifier helper + consistency fixes

### DIFF
--- a/jws/ecdsa.go
+++ b/jws/ecdsa.go
@@ -7,7 +7,6 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"encoding/base64"
-	"errors"
 	"fmt"
 	"math/big"
 
@@ -251,26 +250,7 @@ func NewSourcedECDSAVerifier(source *jwk.Source[*ecdsa.PublicKey], preset ECDSAP
 }
 
 func (verifier *SourcedECDSAVerifier) Transform(ctx context.Context, header *jwa.JWH, rawToken string) ([]byte, error) {
-	keys, err := verifier.source.List(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("(SourcedECDSAVerifier.Transform) %w", err)
-	}
-
-	for _, key := range keys {
-		// A token that names a KID can only match that key; skip the rest.
-		if header.KID != "" && key.KID != header.KID {
-			continue
-		}
-
-		token, err := NewECDSAVerifier(key.Key(), verifier.preset).Transform(ctx, header, rawToken)
-		if err == nil {
-			return token, nil
-		}
-
-		if !errors.Is(err, ErrInvalidSignature) {
-			return nil, fmt.Errorf("(SourcedECDSAVerifier.Transform) %w", err)
-		}
-	}
-
-	return nil, fmt.Errorf("(SourcedECDSAVerifier.Transform) %w", ErrInvalidSignature)
+	return verifyFromSource(ctx, verifier.source, header, rawToken, func(key *ecdsa.PublicKey) jwt.RecipientPlugin {
+		return NewECDSAVerifier(key, verifier.preset)
+	})
 }

--- a/jws/ed25519.go
+++ b/jws/ed25519.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/ed25519"
 	"encoding/base64"
-	"errors"
 	"fmt"
 
 	"github.com/a-novel-kit/jwt"
@@ -159,26 +158,7 @@ func NewSourcedED25519Verifier(source *jwk.Source[ed25519.PublicKey]) *SourcedED
 func (verifier *SourcedED25519Verifier) Transform(
 	ctx context.Context, header *jwa.JWH, rawToken string,
 ) ([]byte, error) {
-	keys, err := verifier.source.List(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("(SourcedED25519Verifier.Transform) %w", err)
-	}
-
-	for _, key := range keys {
-		// A token that names a KID can only match that key; skip the rest.
-		if header.KID != "" && key.KID != header.KID {
-			continue
-		}
-
-		token, err := NewED25519Verifier(key.Key()).Transform(ctx, header, rawToken)
-		if err == nil {
-			return token, nil
-		}
-
-		if !errors.Is(err, ErrInvalidSignature) {
-			return nil, fmt.Errorf("(SourcedED25519Verifier.Transform) %w", err)
-		}
-	}
-
-	return nil, fmt.Errorf("(SourcedED25519Verifier.Transform) %w", ErrInvalidSignature)
+	return verifyFromSource(ctx, verifier.source, header, rawToken, func(key ed25519.PublicKey) jwt.RecipientPlugin {
+		return NewED25519Verifier(key)
+	})
 }

--- a/jws/hmac.go
+++ b/jws/hmac.go
@@ -5,7 +5,6 @@ import (
 	"crypto"
 	"crypto/hmac"
 	"encoding/base64"
-	"errors"
 	"fmt"
 
 	"github.com/a-novel-kit/jwt"
@@ -230,26 +229,7 @@ func NewSourcedHMACVerifier(source *jwk.Source[[]byte], preset HMACPreset) *Sour
 }
 
 func (verifier *SourceHMACVerifier) Transform(ctx context.Context, header *jwa.JWH, rawToken string) ([]byte, error) {
-	keys, err := verifier.source.List(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("(SourceHMACVerifier.Transform) %w", err)
-	}
-
-	for _, key := range keys {
-		// A token that names a KID can only match that secret; skip the rest.
-		if header.KID != "" && key.KID != header.KID {
-			continue
-		}
-
-		token, err := NewHMACVerifier(key.Key(), verifier.preset).Transform(ctx, header, rawToken)
-		if err == nil {
-			return token, nil
-		}
-
-		if !errors.Is(err, ErrInvalidSignature) {
-			return nil, fmt.Errorf("(SourceHMACVerifier.Transform) %w", err)
-		}
-	}
-
-	return nil, fmt.Errorf("(SourceHMACVerifier.Transform) %w", ErrInvalidSignature)
+	return verifyFromSource(ctx, verifier.source, header, rawToken, func(key []byte) jwt.RecipientPlugin {
+		return NewHMACVerifier(key, verifier.preset)
+	})
 }

--- a/jws/hmac_test.go
+++ b/jws/hmac_test.go
@@ -262,13 +262,13 @@ func TestHMACSourcedVerifier(t *testing.T) {
 				newSecretKey, err := jwk.GenerateHMAC(testCase.keyPreset)
 				require.NoError(t, err)
 
-				source = testutils.NewStaticKeysSource(
+				secondSource := testutils.NewStaticKeysSource(
 					t,
 					append([]*jwk.Key[[]byte]{newSecretKey}, secretKeys...),
 				)
 
 				recipient := jwt.NewRecipient(jwt.RecipientConfig{
-					Plugins: []jwt.RecipientPlugin{jws.NewSourcedHMACVerifier(source, testCase.preset)},
+					Plugins: []jwt.RecipientPlugin{jws.NewSourcedHMACVerifier(secondSource, testCase.preset)},
 				})
 
 				var recipientClaims map[string]any
@@ -284,10 +284,10 @@ func TestHMACSourcedVerifier(t *testing.T) {
 				newSecretKey, err := jwk.GenerateHMAC(testCase.keyPreset)
 				require.NoError(t, err)
 
-				source = testutils.NewStaticKeysSource(t, []*jwk.Key[[]byte]{newSecretKey})
+				missingSource := testutils.NewStaticKeysSource(t, []*jwk.Key[[]byte]{newSecretKey})
 
 				recipient := jwt.NewRecipient(jwt.RecipientConfig{
-					Plugins: []jwt.RecipientPlugin{jws.NewSourcedHMACVerifier(source, testCase.preset)},
+					Plugins: []jwt.RecipientPlugin{jws.NewSourcedHMACVerifier(missingSource, testCase.preset)},
 				})
 
 				var recipientClaims map[string]any

--- a/jws/rsa.go
+++ b/jws/rsa.go
@@ -235,26 +235,7 @@ func NewSourcedRSAVerifier(source *jwk.Source[*rsa.PublicKey], preset RSAPreset)
 func (verifier *SourcedRSAVerifier) Transform(
 	ctx context.Context, header *jwa.JWH, rawToken string,
 ) ([]byte, error) {
-	keys, err := verifier.source.List(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("(SourcedRSAVerifier.Transform) %w", err)
-	}
-
-	for _, key := range keys {
-		// A token that names a KID can only match that key; skip the rest.
-		if header.KID != "" && key.KID != header.KID {
-			continue
-		}
-
-		token, err := NewRSAVerifier(key.Key(), verifier.preset).Transform(ctx, header, rawToken)
-		if err == nil {
-			return token, nil
-		}
-
-		if !errors.Is(err, ErrInvalidSignature) {
-			return nil, fmt.Errorf("(SourcedRSAVerifier.Transform) %w", err)
-		}
-	}
-
-	return nil, fmt.Errorf("(SourcedRSAVerifier.Transform) %w", ErrInvalidSignature)
+	return verifyFromSource(ctx, verifier.source, header, rawToken, func(key *rsa.PublicKey) jwt.RecipientPlugin {
+		return NewRSAVerifier(key, verifier.preset)
+	})
 }

--- a/jws/rsa_pss.go
+++ b/jws/rsa_pss.go
@@ -239,26 +239,7 @@ func NewSourcedRSAPSSVerifier(source *jwk.Source[*rsa.PublicKey], preset RSAPSSP
 func (verifier *SourcedRSAPSSVerifier) Transform(
 	ctx context.Context, header *jwa.JWH, rawToken string,
 ) ([]byte, error) {
-	keys, err := verifier.source.List(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("(SourcedRSAPSSVerifier.Transform) %w", err)
-	}
-
-	for _, key := range keys {
-		// A token that names a KID can only match that key; skip the rest.
-		if header.KID != "" && key.KID != header.KID {
-			continue
-		}
-
-		token, err := NewRSAPSSVerifier(key.Key(), verifier.preset).Transform(ctx, header, rawToken)
-		if err == nil {
-			return token, nil
-		}
-
-		if !errors.Is(err, ErrInvalidSignature) {
-			return nil, fmt.Errorf("(SourcedRSAPSSVerifier.Transform) %w", err)
-		}
-	}
-
-	return nil, fmt.Errorf("(SourcedRSAPSSVerifier.Transform) %w", ErrInvalidSignature)
+	return verifyFromSource(ctx, verifier.source, header, rawToken, func(key *rsa.PublicKey) jwt.RecipientPlugin {
+		return NewRSAPSSVerifier(key, verifier.preset)
+	})
 }

--- a/jws/sourced.go
+++ b/jws/sourced.go
@@ -1,0 +1,45 @@
+package jws
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/a-novel-kit/jwt"
+	"github.com/a-novel-kit/jwt/jwa"
+	"github.com/a-novel-kit/jwt/jwk"
+)
+
+// verifyFromSource tries each key the source lists, honoring a KID hint, until one verifies the
+// token or every candidate fails with a signature mismatch. newVerifier builds a single-key
+// verifier for a resolved key. It centralizes the loop the Sourced*Verifier types all shared.
+func verifyFromSource[K any](
+	ctx context.Context,
+	source *jwk.Source[K],
+	header *jwa.JWH,
+	rawToken string,
+	newVerifier func(key K) jwt.RecipientPlugin,
+) ([]byte, error) {
+	keys, err := source.List(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("(verifyFromSource) list keys: %w", err)
+	}
+
+	for _, key := range keys {
+		// A token that names a KID can only match that key; skip the rest.
+		if header.KID != "" && key.KID != header.KID {
+			continue
+		}
+
+		payload, err := newVerifier(key.Key()).Transform(ctx, header, rawToken)
+		if err == nil {
+			return payload, nil
+		}
+
+		if !errors.Is(err, ErrInvalidSignature) {
+			return nil, fmt.Errorf("(verifyFromSource) %w", err)
+		}
+	}
+
+	return nil, fmt.Errorf("(verifyFromSource) %w", ErrInvalidSignature)
+}

--- a/producer_claims.go
+++ b/producer_claims.go
@@ -45,7 +45,7 @@ func NewBasicClaims(payload any, config ClaimsProducerConfig) (*jwa.Claims, erro
 			Iss: config.Issuer,
 			Sub: config.Subject,
 			Aud: config.Audience,
-			Exp: lo.Ternary(config.TTL == 0, 0, time.Now().Add(config.TTL).Unix()),
+			Exp: lo.Ternary(config.TTL == 0, 0, now.Add(config.TTL).Unix()),
 			Nbf: now.Unix(),
 			Iat: now.Unix(),
 			Jti: uuid.NewString(),


### PR DESCRIPTION
## Summary

Task #425 of Epic #430 — the non-breaking consistency/cleanup items.

- **M6** (`refactor`): the five `Sourced*Verifier` types each reimplemented the same list-keys / KID-filter / try-each-key loop. Extracted into one generic `verifyFromSource`; each `Transform` is now a 3-line call.
- **M10** (`fix`): `NewBasicClaims` computed `exp` from a *fresh* `time.Now()` rather than the `now` used for `iat`/`nbf`, so the claims could straddle two instants. Uses one instant now.
- **Bonus** (`test`): fixed a data race in `TestHMACSourcedVerifier` — two parallel subtests reassigned a shared `source` var a third read concurrently.

The doc-rot items (the "JSON Web CEK" comment corruption, the RSA-PSS `PS256` comment) were **already fixed** by the earlier docs-refocus work — 0 occurrences remain.

## Deferred (breaking → Stage 2)

The remaining M7/M8 items rename *exported* symbols or change the `ProducerPlugin` interface, so they're breaking and belong in v2.0.0 (tracked separately): the `Source*`→`Sourced*` type renames, `PBES2KeyEncKWConfig`→`…Manager`, the Ed25519 preset asymmetry, and dropping the `Header` return value (M8).

## Compatibility

Non-breaking. `verifyFromSource` is unexported; error *text* changed prefix but the sentinels (`ErrInvalidSignature`) are unchanged.

## Test plan

- [x] `go test ./...` passes; `TestHMACSourcedVerifier` now runs clean repeatedly.

Closes #425