### PR TITLE
fix(jwe): bind the protected header as AEAD additional data (S4)

### DIFF
--- a/jwe/aec_gcm_test.go
+++ b/jwe/aec_gcm_test.go
@@ -324,3 +324,33 @@ func TestAESGCMBadTag(t *testing.T) {
 	var claims map[string]any
 	require.ErrorIs(t, recipient.Consume(t.Context(), parts.String(), &claims), jwe.ErrInvalidToken)
 }
+
+func TestAESGCMHeaderBound(t *testing.T) {
+	t.Parallel()
+
+	key, err := jwk.GenerateAES(jwk.A256GCM)
+	require.NoError(t, err)
+
+	encrypter := jwe.NewAESGCMEncryption(&jwe.AESGCMEncryptionConfig{
+		CEKManager: &fakeCEKManager{cek: key.Key(), encrypted: []byte("encrypted")},
+	}, jwe.A256GCM)
+	producer := jwt.NewProducer(jwt.ProducerConfig{Plugins: []jwt.ProducerPlugin{encrypter}})
+
+	token, err := producer.Issue(t.Context(), map[string]any{"foo": "bar"}, nil)
+	require.NoError(t, err)
+
+	// The protected header is bound as AAD now. Swapping it for a different (still enc-valid) header
+	// must fail decryption.
+	parts, err := jwt.DecodeToken(token, &jwt.EncryptedTokenDecoder{})
+	require.NoError(t, err)
+
+	parts.Header = base64.RawURLEncoding.EncodeToString([]byte(`{"enc":"A256GCM","x":1}`))
+
+	decrypter := jwe.NewAESGCMDecryption(&jwe.AESGCMDecryptionConfig{
+		CEKDecoder: &fakeCEKDecoder{cek: key.Key(), encrypted: []byte("encrypted")},
+	}, jwe.A256GCM)
+	recipient := jwt.NewRecipient(jwt.RecipientConfig{Plugins: []jwt.RecipientPlugin{decrypter}})
+
+	var claims map[string]any
+	require.Error(t, recipient.Consume(t.Context(), parts.String(), &claims))
+}

--- a/jwe/aec_gcm_test.go
+++ b/jwe/aec_gcm_test.go
@@ -352,5 +352,7 @@ func TestAESGCMHeaderBound(t *testing.T) {
 	recipient := jwt.NewRecipient(jwt.RecipientConfig{Plugins: []jwt.RecipientPlugin{decrypter}})
 
 	var claims map[string]any
-	require.Error(t, recipient.Consume(t.Context(), parts.String(), &claims))
+
+	// The tamper fails as an authenticated-decryption error, not an unrelated parse failure.
+	require.ErrorIs(t, recipient.Consume(t.Context(), parts.String(), &claims), jwe.ErrInvalidSecret)
 }

--- a/jwe/aes_cbc.go
+++ b/jwe/aes_cbc.go
@@ -166,15 +166,17 @@ func (enc *AESCBCEncryption) Transform(ctx context.Context, header *jwa.JWH, raw
 	cipherText := make([]byte, len(origData))
 	blockMode.CryptBlocks(cipherText, origData)
 
-	// AL is the additional-data length in bits as a big-endian uint64. It is the last
-	// input to the tag, so the recipient can bind the length it authenticated.
-	al := make([]byte, 8)
-	binary.BigEndian.PutUint64(al, uint64(len(enc.additionalData)*8))
+	// AAD binds the encoded protected header (RFC 7516 §5.1) plus any application data. AL is its
+	// length in bits as a big-endian uint64, the last input to the tag.
+	aadBytes := aad(token.Header, enc.additionalData)
 
-	// The tag is HMAC over the additional data, IV, ciphertext, and AL in that order,
-	// truncated to tagLength octets. The order is fixed by the spec.
+	al := make([]byte, 8)
+	binary.BigEndian.PutUint64(al, uint64(len(aadBytes)*8))
+
+	// The tag is HMAC over AAD, IV, ciphertext, and AL in that order, truncated to tagLength
+	// octets. The order is fixed by the spec.
 	authenticationTag := hmac.New(enc.hash.New, macKey)
-	authenticationTag.Write(enc.additionalData)
+	authenticationTag.Write(aadBytes)
 	authenticationTag.Write(iv)
 	authenticationTag.Write(cipherText)
 	authenticationTag.Write(al)
@@ -301,14 +303,16 @@ func (dec *AESCBCDecryption) Transform(ctx context.Context, header *jwa.JWH, raw
 	encKey := cek[dec.keyLength:]
 	macKey := cek[:dec.macKeyLength]
 
-	// Recompute the tag over the same inputs as encryption and reject the token unless
-	// it matches, before touching the ciphertext. hmac.Equal compares in constant time
-	// to avoid leaking the tag through timing.
+	// Recompute the tag over the same inputs as encryption — including the encoded protected header
+	// as AAD — and reject the token unless it matches, before touching the ciphertext. hmac.Equal
+	// compares in constant time to avoid leaking the tag through timing.
+	aadBytes := aad(token.Header, dec.additionalData)
+
 	al := make([]byte, 8)
-	binary.BigEndian.PutUint64(al, uint64(len(dec.additionalData)*8))
+	binary.BigEndian.PutUint64(al, uint64(len(aadBytes)*8))
 
 	mac := hmac.New(dec.hash.New, macKey)
-	mac.Write(dec.additionalData)
+	mac.Write(aadBytes)
 	mac.Write(iv)
 	mac.Write(cipherText)
 	mac.Write(al)

--- a/jwe/aes_gcm.go
+++ b/jwe/aes_gcm.go
@@ -132,7 +132,7 @@ func (enc *AESGCMEncryption) Transform(ctx context.Context, header *jwa.JWH, raw
 
 	// Seal appends the authentication tag to the ciphertext; JWE carries them in
 	// separate fields, so split off the trailing Overhead() bytes.
-	ciphertextAndTag := aesgcm.Seal(nil, iv, plainText, enc.additionalData)
+	ciphertextAndTag := aesgcm.Seal(nil, iv, plainText, aad(token.Header, enc.additionalData))
 	cipherLen := len(ciphertextAndTag) - aesgcm.Overhead()
 	cipherText := ciphertextAndTag[:cipherLen]
 	tag := ciphertextAndTag[cipherLen:]
@@ -270,7 +270,7 @@ func (dec *AESGCMDecryption) Transform(ctx context.Context, header *jwa.JWH, raw
 		)
 	}
 
-	plainText, err := aesgcm.Open(nil, iv, append(cipherText, tag...), dec.additionalData)
+	plainText, err := aesgcm.Open(nil, iv, append(cipherText, tag...), aad(token.Header, dec.additionalData))
 	if err != nil {
 		// An authenticated-decryption failure is the GCM analogue of a bad HMAC tag; surface the
 		// same sentinel the CBC path uses so callers can treat auth failures uniformly.

--- a/jwe/common.go
+++ b/jwe/common.go
@@ -1,6 +1,9 @@
 package jwe
 
-import "errors"
+import (
+	"encoding/base64"
+	"errors"
+)
 
 // ErrInvalidSecret is returned when the content encryption key resolved for a token
 // has the wrong length for the chosen algorithm, or when an authentication tag fails
@@ -10,3 +13,18 @@ var ErrInvalidSecret = errors.New("invalid secret")
 // ErrInvalidToken is returned when an encrypted token is structurally malformed — for example an
 // initialization vector or padding of the wrong length.
 var ErrInvalidToken = errors.New("invalid token")
+
+// aad builds the additional authenticated data the AEAD binds: the encoded protected header
+// (RFC 7516 §5.1), plus the application additionalData appended as ".BASE64URL(additionalData)" when
+// present (the JWE JSON-serialization AAD rule). Both encrypt and decrypt derive it from the
+// transmitted header, so tampering with the header fails the integrity check.
+func aad(encodedHeader string, additionalData []byte) []byte {
+	out := []byte(encodedHeader)
+	if len(additionalData) == 0 {
+		return out
+	}
+
+	out = append(out, '.')
+
+	return append(out, base64.RawURLEncoding.EncodeToString(additionalData)...)
+}

--- a/jwe/common.go
+++ b/jwe/common.go
@@ -14,10 +14,11 @@ var ErrInvalidSecret = errors.New("invalid secret")
 // initialization vector or padding of the wrong length.
 var ErrInvalidToken = errors.New("invalid token")
 
-// aad builds the additional authenticated data the AEAD binds: the encoded protected header
-// (RFC 7516 §5.1), plus the application additionalData appended as ".BASE64URL(additionalData)" when
-// present (the JWE JSON-serialization AAD rule). Both encrypt and decrypt derive it from the
-// transmitted header, so tampering with the header fails the integrity check.
+// aad builds the additional data bound into the JWE integrity check — used as the AEAD AAD for
+// AES-GCM and folded into the HMAC for AES-CBC-HMAC: the encoded protected header (RFC 7516 §5.1),
+// plus the application additionalData appended as ".BASE64URL(additionalData)" when present (the JWE
+// JSON-serialization AAD rule). Both encrypt and decrypt derive it from the transmitted header, so
+// tampering with the header fails the integrity check.
 func aad(encodedHeader string, additionalData []byte) []byte {
 	out := []byte(encodedHeader)
 	if len(additionalData) == 0 {


### PR DESCRIPTION
## Summary

Task #433 (split from #421) of Epic #430. Closes the last JWE integrity gap: the protected header was **not authenticated**.

RFC 7516 §5.1 requires the AEAD's additional authenticated data to be `ASCII(BASE64URL(protected header))`. The code instead fed a static `AdditionalData` config field, so a valid tag left header parameters (kid, zip, crit, custom params — worst under `dir`) malleable.

- New shared `aad(encodedHeader, additionalData)` helper: the encoded protected header, plus the application `AdditionalData` appended as `.BASE64URL(...)` when set (the JWE JSON-serialization AAD rule).
- **AES-CBC-HMAC**: the header is now part of the HMAC input and the `AL` length; **AES-GCM**: it's the `Seal`/`Open` AAD. Both encrypt and decrypt derive it from the transmitted header, so any header tamper fails the tag.

## Compatibility

Interop-affecting by nature (it changes the tag/ciphertext authentication), but **no consumer produces JWE yet**, so there's no migration burden — land before any JWE usage begins. The exported API and the `AdditionalData` field are unchanged (the common, empty-`AdditionalData` case simply becomes RFC-compliant header binding).

## Test plan

- [x] `go test ./...` passes — all CBC/GCM round-trips (with and without `AdditionalData`) still succeed since both sides derive the AAD identically.
- [x] New `TestAESGCMHeaderBound`: swapping the protected header for a different (still `enc`-valid) one now fails decryption.

Closes #433