### PR TITLE
chore!: bump module path to github.com/a-novel-kit/jwt/v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A modular JWT, JWS, JWE, and JWK library for Go.
 ![GitHub repo file or directory count](https://img.shields.io/github/directory-file-count/a-novel-kit/jwt)
 ![GitHub code size in bytes](https://img.shields.io/github/languages/code-size/a-novel-kit/jwt)
 ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/a-novel-kit/jwt/main.yaml)
-[![Go Report Card](https://goreportcard.com/badge/github.com/a-novel-kit/jwt)](https://goreportcard.com/report/github.com/a-novel-kit/jwt)
+[![Go Report Card](https://goreportcard.com/badge/github.com/a-novel-kit/jwt/v2)](https://goreportcard.com/report/github.com/a-novel-kit/jwt/v2)
 [![codecov](https://codecov.io/gh/a-novel-kit/jwt/graph/badge.svg)](https://codecov.io/gh/a-novel-kit/jwt)
 
 ![Coverage graph](https://codecov.io/gh/a-novel-kit/jwt/graphs/sunburst.svg)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A modular JWT, JWS, JWE, and JWK library for Go.
 
 ## What this is
 
-`github.com/a-novel-kit/jwt` provides composable building blocks for JSON Web Tokens in Go. The root package produces
+`github.com/a-novel-kit/jwt/v2` provides composable building blocks for JSON Web Tokens in Go. The root package produces
 and consumes token payloads; plugins add signing, verification, encryption, decryption, key headers, and claims
 validation.
 
@@ -33,7 +33,7 @@ responsibility.
 ## Installation
 
 ```bash
-go get github.com/a-novel-kit/jwt
+go get github.com/a-novel-kit/jwt/v2
 ```
 
 The root `jwt.Producer` and `jwt.Recipient` types handle the token lifecycle. With no plugins, they produce and consume

--- a/crit_test.go
+++ b/crit_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/a-novel-kit/jwt"
+	"github.com/a-novel-kit/jwt/v2"
 )
 
 func TestCheckCritUnderstood(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/a-novel-kit/jwt
+module github.com/a-novel-kit/jwt/v2
 
 go 1.26.4
 

--- a/jwa/internal/json_partial_test.go
+++ b/jwa/internal/json_partial_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/a-novel-kit/jwt/jwa/internal"
+	"github.com/a-novel-kit/jwt/v2/jwa/internal"
 )
 
 func TestMarshalPartial(t *testing.T) {

--- a/jwa/jwh.go
+++ b/jwa/jwh.go
@@ -3,7 +3,7 @@ package jwa
 import (
 	"encoding/json"
 
-	"github.com/a-novel-kit/jwt/jwa/internal"
+	"github.com/a-novel-kit/jwt/v2/jwa/internal"
 )
 
 // Typ is the "typ" (type) header parameter. It declares the media type of the

--- a/jwa/jwk.go
+++ b/jwa/jwk.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/samber/lo"
 
-	"github.com/a-novel-kit/jwt/jwa/internal"
+	"github.com/a-novel-kit/jwt/v2/jwa/internal"
 )
 
 // JWKCommon holds the parameters common to every JSON Web Key, independent of

--- a/jwa/jwt.go
+++ b/jwa/jwt.go
@@ -3,7 +3,7 @@ package jwa
 import (
 	"encoding/json"
 
-	"github.com/a-novel-kit/jwt/jwa/internal"
+	"github.com/a-novel-kit/jwt/v2/jwa/internal"
 )
 
 // ClaimsCommon holds the registered claims of a JWT, the standard fields every

--- a/jwe/aec_cbc_test.go
+++ b/jwe/aec_cbc_test.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/a-novel-kit/jwt"
-	"github.com/a-novel-kit/jwt/jwe"
-	"github.com/a-novel-kit/jwt/jwk"
+	"github.com/a-novel-kit/jwt/v2"
+	"github.com/a-novel-kit/jwt/v2/jwe"
+	"github.com/a-novel-kit/jwt/v2/jwk"
 )
 
 func TestAESCBC(t *testing.T) {

--- a/jwe/aec_gcm_test.go
+++ b/jwe/aec_gcm_test.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/a-novel-kit/jwt"
-	"github.com/a-novel-kit/jwt/jwe"
-	"github.com/a-novel-kit/jwt/jwk"
+	"github.com/a-novel-kit/jwt/v2"
+	"github.com/a-novel-kit/jwt/v2/jwe"
+	"github.com/a-novel-kit/jwt/v2/jwk"
 )
 
 func TestAESGCM(t *testing.T) {

--- a/jwe/aes_cbc.go
+++ b/jwe/aes_cbc.go
@@ -11,9 +11,9 @@ import (
 	"encoding/binary"
 	"fmt"
 
-	"github.com/a-novel-kit/jwt"
-	"github.com/a-novel-kit/jwt/jwa"
-	"github.com/a-novel-kit/jwt/jwe/internal"
+	"github.com/a-novel-kit/jwt/v2"
+	"github.com/a-novel-kit/jwt/v2/jwa"
+	"github.com/a-novel-kit/jwt/v2/jwe/internal"
 )
 
 // AESCBCPreset holds the parameters of one AES_CBC_HMAC_SHA2 variant: the enc

--- a/jwe/aes_gcm.go
+++ b/jwe/aes_gcm.go
@@ -8,8 +8,8 @@ import (
 	"encoding/base64"
 	"fmt"
 
-	"github.com/a-novel-kit/jwt"
-	"github.com/a-novel-kit/jwt/jwa"
+	"github.com/a-novel-kit/jwt/v2"
+	"github.com/a-novel-kit/jwt/v2/jwa"
 )
 
 // AESGCMPreset holds the parameters of one AES-GCM variant: the enc identifier and

--- a/jwe/assertions.go
+++ b/jwe/assertions.go
@@ -1,6 +1,6 @@
 package jwe
 
-import "github.com/a-novel-kit/jwt"
+import "github.com/a-novel-kit/jwt/v2"
 
 // Compile-time checks that the content-encryption plugins satisfy the producer/recipient contracts.
 var (

--- a/jwe/internal/concat_kdf_test.go
+++ b/jwe/internal/concat_kdf_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/a-novel-kit/jwt/jwe/internal"
+	"github.com/a-novel-kit/jwt/v2/jwe/internal"
 )
 
 // https://datatracker.ietf.org/doc/html/rfc7518#appendix-C

--- a/jwe/internal/key_wrap_test.go
+++ b/jwe/internal/key_wrap_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/a-novel-kit/jwt/jwe/internal"
+	"github.com/a-novel-kit/jwt/v2/jwe/internal"
 )
 
 func TestAesKeyWrap(t *testing.T) {

--- a/jwe/internal/pkcs_test.go
+++ b/jwe/internal/pkcs_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/a-novel-kit/jwt/jwe/internal"
+	"github.com/a-novel-kit/jwt/v2/jwe/internal"
 )
 
 func TestPKCS7Padding(t *testing.T) {

--- a/jwe/jwek/aes_gcm_key_wrap.go
+++ b/jwe/jwek/aes_gcm_key_wrap.go
@@ -9,8 +9,8 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/a-novel-kit/jwt"
-	"github.com/a-novel-kit/jwt/jwa"
+	"github.com/a-novel-kit/jwt/v2"
+	"github.com/a-novel-kit/jwt/v2/jwa"
 )
 
 // AESGCMKWPreset pairs a JWA algorithm identifier with its wrap-key length. Use

--- a/jwe/jwek/aes_gcm_key_wrap_test.go
+++ b/jwe/jwek/aes_gcm_key_wrap_test.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/a-novel-kit/jwt/jwa"
-	"github.com/a-novel-kit/jwt/jwe/jwek"
-	"github.com/a-novel-kit/jwt/jwk"
+	"github.com/a-novel-kit/jwt/v2/jwa"
+	"github.com/a-novel-kit/jwt/v2/jwe/jwek"
+	"github.com/a-novel-kit/jwt/v2/jwk"
 )
 
 func TestAESGCMKW(t *testing.T) {

--- a/jwe/jwek/aes_key_wrap.go
+++ b/jwe/jwek/aes_key_wrap.go
@@ -5,9 +5,9 @@ import (
 	"crypto/aes"
 	"fmt"
 
-	"github.com/a-novel-kit/jwt"
-	"github.com/a-novel-kit/jwt/jwa"
-	"github.com/a-novel-kit/jwt/jwe/internal"
+	"github.com/a-novel-kit/jwt/v2"
+	"github.com/a-novel-kit/jwt/v2/jwa"
+	"github.com/a-novel-kit/jwt/v2/jwe/internal"
 )
 
 // AESKWPreset pairs a JWA algorithm identifier with its wrap-key length. Use one

--- a/jwe/jwek/aes_key_wrap_test.go
+++ b/jwe/jwek/aes_key_wrap_test.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/a-novel-kit/jwt/jwa"
-	"github.com/a-novel-kit/jwt/jwe/jwek"
-	"github.com/a-novel-kit/jwt/jwk"
+	"github.com/a-novel-kit/jwt/v2/jwa"
+	"github.com/a-novel-kit/jwt/v2/jwe/jwek"
+	"github.com/a-novel-kit/jwt/v2/jwk"
 )
 
 func TestAESKW(t *testing.T) {

--- a/jwe/jwek/assertions.go
+++ b/jwe/jwek/assertions.go
@@ -1,6 +1,6 @@
 package jwek
 
-import "github.com/a-novel-kit/jwt/jwe"
+import "github.com/a-novel-kit/jwt/v2/jwe"
 
 // Compile-time checks that every key manager and decoder satisfies the jwe.CEKManager /
 // jwe.CEKDecoder contract. This is exactly the guard that would have caught DirectKeyManager's

--- a/jwe/jwek/direct_encryption.go
+++ b/jwe/jwek/direct_encryption.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/a-novel-kit/jwt"
-	"github.com/a-novel-kit/jwt/jwa"
+	"github.com/a-novel-kit/jwt/v2"
+	"github.com/a-novel-kit/jwt/v2/jwa"
 )
 
 // DirectKeyManager implements jwe.CEKManager for direct encryption: the content

--- a/jwe/jwek/direct_encryption_test.go
+++ b/jwe/jwek/direct_encryption_test.go
@@ -5,10 +5,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/a-novel-kit/jwt/jwa"
-	"github.com/a-novel-kit/jwt/jwe"
-	"github.com/a-novel-kit/jwt/jwe/jwek"
-	"github.com/a-novel-kit/jwt/jwk"
+	"github.com/a-novel-kit/jwt/v2/jwa"
+	"github.com/a-novel-kit/jwt/v2/jwe"
+	"github.com/a-novel-kit/jwt/v2/jwe/jwek"
+	"github.com/a-novel-kit/jwt/v2/jwk"
 )
 
 // DirectKeyManager plugs into the JWE engine as a jwe.CEKManager ("dir" key management); this

--- a/jwe/jwek/key_derivation_ecdh.go
+++ b/jwe/jwek/key_derivation_ecdh.go
@@ -8,10 +8,10 @@ import (
 
 	"golang.org/x/crypto/curve25519"
 
-	"github.com/a-novel-kit/jwt"
-	"github.com/a-novel-kit/jwt/jwa"
-	"github.com/a-novel-kit/jwt/jwe/internal"
-	"github.com/a-novel-kit/jwt/jwk/serializers"
+	"github.com/a-novel-kit/jwt/v2"
+	"github.com/a-novel-kit/jwt/v2/jwa"
+	"github.com/a-novel-kit/jwt/v2/jwe/internal"
+	"github.com/a-novel-kit/jwt/v2/jwk/serializers"
 )
 
 // ECDHKeyAgrPreset binds a content-encryption algorithm to its derived-key length

--- a/jwe/jwek/key_derivation_ecdh_kw.go
+++ b/jwe/jwek/key_derivation_ecdh_kw.go
@@ -9,10 +9,10 @@ import (
 
 	"golang.org/x/crypto/curve25519"
 
-	"github.com/a-novel-kit/jwt"
-	"github.com/a-novel-kit/jwt/jwa"
-	"github.com/a-novel-kit/jwt/jwe/internal"
-	"github.com/a-novel-kit/jwt/jwk/serializers"
+	"github.com/a-novel-kit/jwt/v2"
+	"github.com/a-novel-kit/jwt/v2/jwa"
+	"github.com/a-novel-kit/jwt/v2/jwe/internal"
+	"github.com/a-novel-kit/jwt/v2/jwk/serializers"
 )
 
 // ECDHKeyAgrKWPreset pairs a JWA algorithm identifier with the length of the

--- a/jwe/jwek/key_derivation_ecdh_kw_test.go
+++ b/jwe/jwek/key_derivation_ecdh_kw_test.go
@@ -5,10 +5,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/a-novel-kit/jwt"
-	"github.com/a-novel-kit/jwt/jwa"
-	"github.com/a-novel-kit/jwt/jwe/jwek"
-	"github.com/a-novel-kit/jwt/jwk"
+	"github.com/a-novel-kit/jwt/v2"
+	"github.com/a-novel-kit/jwt/v2/jwa"
+	"github.com/a-novel-kit/jwt/v2/jwe/jwek"
+	"github.com/a-novel-kit/jwt/v2/jwk"
 )
 
 func TestECDHKeyAgrKW(t *testing.T) {

--- a/jwe/jwek/key_derivation_ecdh_test.go
+++ b/jwe/jwek/key_derivation_ecdh_test.go
@@ -5,10 +5,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/a-novel-kit/jwt"
-	"github.com/a-novel-kit/jwt/jwa"
-	"github.com/a-novel-kit/jwt/jwe/jwek"
-	"github.com/a-novel-kit/jwt/jwk"
+	"github.com/a-novel-kit/jwt/v2"
+	"github.com/a-novel-kit/jwt/v2/jwa"
+	"github.com/a-novel-kit/jwt/v2/jwe/jwek"
+	"github.com/a-novel-kit/jwt/v2/jwk"
 )
 
 func TestECDHKeyAgr(t *testing.T) {

--- a/jwe/jwek/pbes2_key_enc.go
+++ b/jwe/jwek/pbes2_key_enc.go
@@ -10,9 +10,9 @@ import (
 
 	"golang.org/x/crypto/pbkdf2"
 
-	"github.com/a-novel-kit/jwt"
-	"github.com/a-novel-kit/jwt/jwa"
-	"github.com/a-novel-kit/jwt/jwe/internal"
+	"github.com/a-novel-kit/jwt/v2"
+	"github.com/a-novel-kit/jwt/v2/jwa"
+	"github.com/a-novel-kit/jwt/v2/jwe/internal"
 )
 
 // PBES2KeyEncKWPreset pairs a JWA algorithm identifier with the hash and key size

--- a/jwe/jwek/pbes2_key_enc_test.go
+++ b/jwe/jwek/pbes2_key_enc_test.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/a-novel-kit/jwt/jwa"
-	"github.com/a-novel-kit/jwt/jwe/jwek"
-	"github.com/a-novel-kit/jwt/jwk"
+	"github.com/a-novel-kit/jwt/v2/jwa"
+	"github.com/a-novel-kit/jwt/v2/jwe/jwek"
+	"github.com/a-novel-kit/jwt/v2/jwk"
 )
 
 func TestPBES2KeyEncKW(t *testing.T) {

--- a/jwe/jwek/rsa_oaep_key_enc.go
+++ b/jwe/jwek/rsa_oaep_key_enc.go
@@ -9,8 +9,8 @@ import (
 	"fmt"
 	"hash"
 
-	"github.com/a-novel-kit/jwt"
-	"github.com/a-novel-kit/jwt/jwa"
+	"github.com/a-novel-kit/jwt/v2"
+	"github.com/a-novel-kit/jwt/v2/jwa"
 )
 
 // RSAOAEPKeyEncPreset pairs a JWA algorithm identifier with the hash used by

--- a/jwe/jwek/rsa_oaep_key_enc_test.go
+++ b/jwe/jwek/rsa_oaep_key_enc_test.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/a-novel-kit/jwt/jwa"
-	"github.com/a-novel-kit/jwt/jwe/jwek"
-	"github.com/a-novel-kit/jwt/jwk"
+	"github.com/a-novel-kit/jwt/v2/jwa"
+	"github.com/a-novel-kit/jwt/v2/jwe/jwek"
+	"github.com/a-novel-kit/jwt/v2/jwk"
 )
 
 func TestRSAOAEPKeyEnc(t *testing.T) {

--- a/jwe/key_manager.go
+++ b/jwe/key_manager.go
@@ -3,7 +3,7 @@ package jwe
 import (
 	"context"
 
-	"github.com/a-novel-kit/jwt/jwa"
+	"github.com/a-novel-kit/jwt/v2/jwa"
 )
 
 // CEKManager supplies the content encryption key (CEK) to an encryption plugin and

--- a/jwe/utils_test.go
+++ b/jwe/utils_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 
-	"github.com/a-novel-kit/jwt/jwa"
+	"github.com/a-novel-kit/jwt/v2/jwa"
 )
 
 var errFoo = errors.New("foo error")

--- a/jwk/aes.go
+++ b/jwk/aes.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/a-novel-kit/jwt/jwa"
-	"github.com/a-novel-kit/jwt/jwk/generators"
-	"github.com/a-novel-kit/jwt/jwk/serializers"
+	"github.com/a-novel-kit/jwt/v2/jwa"
+	"github.com/a-novel-kit/jwt/v2/jwk/generators"
+	"github.com/a-novel-kit/jwt/v2/jwk/serializers"
 )
 
 // An AESPreset describes how to generate or match an AES JSON Web Key: the algorithm it is bound

--- a/jwk/aes_test.go
+++ b/jwk/aes_test.go
@@ -9,9 +9,9 @@ import (
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 
-	"github.com/a-novel-kit/jwt/jwa"
-	"github.com/a-novel-kit/jwt/jwk"
-	"github.com/a-novel-kit/jwt/jwk/serializers"
+	"github.com/a-novel-kit/jwt/v2/jwa"
+	"github.com/a-novel-kit/jwt/v2/jwk"
+	"github.com/a-novel-kit/jwt/v2/jwk/serializers"
 )
 
 func mustAES(t *testing.T, preset jwk.AESPreset) *jwk.Key[[]byte] {

--- a/jwk/common.go
+++ b/jwk/common.go
@@ -9,7 +9,7 @@ package jwk
 import (
 	"errors"
 
-	"github.com/a-novel-kit/jwt/jwa"
+	"github.com/a-novel-kit/jwt/v2/jwa"
 )
 
 // ErrJWKMismatch is returned when a JSON Web Key does not match the preset it is parsed against —

--- a/jwk/common_test.go
+++ b/jwk/common_test.go
@@ -3,8 +3,8 @@ package jwk_test
 import (
 	"testing"
 
-	"github.com/a-novel-kit/jwt/jwa"
-	"github.com/a-novel-kit/jwt/jwk"
+	"github.com/a-novel-kit/jwt/v2/jwa"
+	"github.com/a-novel-kit/jwt/v2/jwk"
 )
 
 func newBullshitKey[K any](t *testing.T, kid string) *jwk.Key[K] {

--- a/jwk/ecdh.go
+++ b/jwk/ecdh.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/a-novel-kit/jwt/jwa"
-	"github.com/a-novel-kit/jwt/jwk/serializers"
+	"github.com/a-novel-kit/jwt/v2/jwa"
+	"github.com/a-novel-kit/jwt/v2/jwk/serializers"
 )
 
 // GenerateECDH generates a new ECDH key pair on the X25519 curve.

--- a/jwk/ecdh_test.go
+++ b/jwk/ecdh_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 
-	"github.com/a-novel-kit/jwt/jwa"
-	"github.com/a-novel-kit/jwt/jwk"
-	"github.com/a-novel-kit/jwt/jwk/serializers"
+	"github.com/a-novel-kit/jwt/v2/jwa"
+	"github.com/a-novel-kit/jwt/v2/jwk"
+	"github.com/a-novel-kit/jwt/v2/jwk/serializers"
 )
 
 func mustECDH(t *testing.T) (*jwk.Key[*ecdh.PrivateKey], *jwk.Key[*ecdh.PublicKey]) {

--- a/jwk/ecdsa.go
+++ b/jwk/ecdsa.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/a-novel-kit/jwt/jwa"
-	"github.com/a-novel-kit/jwt/jwk/serializers"
+	"github.com/a-novel-kit/jwt/v2/jwa"
+	"github.com/a-novel-kit/jwt/v2/jwk/serializers"
 )
 
 // An ECDSAPreset describes how to generate or match an ECDSA JSON Web Key: the algorithm it is

--- a/jwk/ecdsa_test.go
+++ b/jwk/ecdsa_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 
-	"github.com/a-novel-kit/jwt/jwa"
-	"github.com/a-novel-kit/jwt/jwk"
-	"github.com/a-novel-kit/jwt/jwk/serializers"
+	"github.com/a-novel-kit/jwt/v2/jwa"
+	"github.com/a-novel-kit/jwt/v2/jwk"
+	"github.com/a-novel-kit/jwt/v2/jwk/serializers"
 )
 
 func mustECDSA(t *testing.T, preset jwk.ECDSAPreset) (*jwk.Key[*ecdsa.PrivateKey], *jwk.Key[*ecdsa.PublicKey]) {

--- a/jwk/ed25519.go
+++ b/jwk/ed25519.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/a-novel-kit/jwt/jwa"
-	"github.com/a-novel-kit/jwt/jwk/serializers"
+	"github.com/a-novel-kit/jwt/v2/jwa"
+	"github.com/a-novel-kit/jwt/v2/jwk/serializers"
 )
 
 // GenerateED25519 generates a new Ed25519 key pair.

--- a/jwk/ed25519_test.go
+++ b/jwk/ed25519_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 
-	"github.com/a-novel-kit/jwt/jwa"
-	"github.com/a-novel-kit/jwt/jwk"
-	"github.com/a-novel-kit/jwt/jwk/serializers"
+	"github.com/a-novel-kit/jwt/v2/jwa"
+	"github.com/a-novel-kit/jwt/v2/jwk"
+	"github.com/a-novel-kit/jwt/v2/jwk/serializers"
 )
 
 func mustED25519(t *testing.T) (*jwk.Key[ed25519.PrivateKey], *jwk.Key[ed25519.PublicKey]) {

--- a/jwk/generators/oct_test.go
+++ b/jwk/generators/oct_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/a-novel-kit/jwt/jwk/generators"
+	"github.com/a-novel-kit/jwt/v2/jwk/generators"
 )
 
 func TestNewOct(t *testing.T) {

--- a/jwk/hmac.go
+++ b/jwk/hmac.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/a-novel-kit/jwt/jwa"
-	"github.com/a-novel-kit/jwt/jwk/generators"
-	"github.com/a-novel-kit/jwt/jwk/serializers"
+	"github.com/a-novel-kit/jwt/v2/jwa"
+	"github.com/a-novel-kit/jwt/v2/jwk/generators"
+	"github.com/a-novel-kit/jwt/v2/jwk/serializers"
 )
 
 // An HMACPreset describes how to generate or match an HMAC JSON Web Key: the algorithm it is bound

--- a/jwk/hmac_test.go
+++ b/jwk/hmac_test.go
@@ -9,9 +9,9 @@ import (
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 
-	"github.com/a-novel-kit/jwt/jwa"
-	"github.com/a-novel-kit/jwt/jwk"
-	"github.com/a-novel-kit/jwt/jwk/serializers"
+	"github.com/a-novel-kit/jwt/v2/jwa"
+	"github.com/a-novel-kit/jwt/v2/jwk"
+	"github.com/a-novel-kit/jwt/v2/jwk/serializers"
 )
 
 func mustHMAC(t *testing.T, preset jwk.HMACPreset) *jwk.Key[[]byte] {

--- a/jwk/rsa.go
+++ b/jwk/rsa.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/a-novel-kit/jwt/jwa"
-	"github.com/a-novel-kit/jwt/jwk/serializers"
+	"github.com/a-novel-kit/jwt/v2/jwa"
+	"github.com/a-novel-kit/jwt/v2/jwk/serializers"
 )
 
 // An RSAPreset describes how to generate or match an RSA JSON Web Key: the algorithm it is bound

--- a/jwk/rsa_test.go
+++ b/jwk/rsa_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 
-	"github.com/a-novel-kit/jwt/jwa"
-	"github.com/a-novel-kit/jwt/jwk"
-	"github.com/a-novel-kit/jwt/jwk/serializers"
+	"github.com/a-novel-kit/jwt/v2/jwa"
+	"github.com/a-novel-kit/jwt/v2/jwk"
+	"github.com/a-novel-kit/jwt/v2/jwk/serializers"
 )
 
 func mustRSA(t *testing.T, preset jwk.RSAPreset) (*jwk.Key[*rsa.PrivateKey], *jwk.Key[*rsa.PublicKey]) {

--- a/jwk/serializers/ecdh.go
+++ b/jwk/serializers/ecdh.go
@@ -5,7 +5,7 @@ import (
 	"encoding/base64"
 	"fmt"
 
-	"github.com/a-novel-kit/jwt/jwa"
+	"github.com/a-novel-kit/jwt/v2/jwa"
 )
 
 // An ECDHPayload wraps an ECDH-ES key in a JWKCommon format.

--- a/jwk/serializers/ecdh_test.go
+++ b/jwk/serializers/ecdh_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/a-novel-kit/jwt/jwk/serializers"
+	"github.com/a-novel-kit/jwt/v2/jwk/serializers"
 )
 
 func TestECDH(t *testing.T) {

--- a/jwk/serializers/ecdsa_test.go
+++ b/jwk/serializers/ecdsa_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/a-novel-kit/jwt/jwk/serializers"
+	"github.com/a-novel-kit/jwt/v2/jwk/serializers"
 )
 
 func TestEC(t *testing.T) {

--- a/jwk/serializers/ed25519.go
+++ b/jwk/serializers/ed25519.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/a-novel-kit/jwt/jwa"
+	"github.com/a-novel-kit/jwt/v2/jwa"
 )
 
 // An EDPayload wraps an EdDSA key in a JWKCommon format.

--- a/jwk/serializers/ed25519_test.go
+++ b/jwk/serializers/ed25519_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/a-novel-kit/jwt/jwk/serializers"
+	"github.com/a-novel-kit/jwt/v2/jwk/serializers"
 )
 
 func TestED(t *testing.T) {

--- a/jwk/serializers/oct_test.go
+++ b/jwk/serializers/oct_test.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/a-novel-kit/jwt/jwk/generators"
-	"github.com/a-novel-kit/jwt/jwk/serializers"
+	"github.com/a-novel-kit/jwt/v2/jwk/generators"
+	"github.com/a-novel-kit/jwt/v2/jwk/serializers"
 )
 
 func TestOct(t *testing.T) {

--- a/jwk/serializers/rsa_test.go
+++ b/jwk/serializers/rsa_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/a-novel-kit/jwt/jwk/serializers"
+	"github.com/a-novel-kit/jwt/v2/jwk/serializers"
 )
 
 func TestRSA(t *testing.T) {

--- a/jwk/source.go
+++ b/jwk/source.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/a-novel-kit/jwt/jwa"
+	"github.com/a-novel-kit/jwt/v2/jwa"
 )
 
 // ErrKeyNotFound is returned by [Source.Get] when no cached key matches the request.

--- a/jwk/source_test.go
+++ b/jwk/source_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/a-novel-kit/jwt/jwa"
-	"github.com/a-novel-kit/jwt/jwk"
+	"github.com/a-novel-kit/jwt/v2/jwa"
+	"github.com/a-novel-kit/jwt/v2/jwk"
 )
 
 type simulatedParserResp[K any] struct {

--- a/jwp/assertions.go
+++ b/jwp/assertions.go
@@ -1,6 +1,6 @@
 package jwp
 
-import "github.com/a-novel-kit/jwt"
+import "github.com/a-novel-kit/jwt/v2"
 
 // Compile-time checks for the higher-level helpers: the key embedder is a static producer plugin,
 // and the claim checks satisfy the checker interfaces.

--- a/jwp/claims_checker.go
+++ b/jwp/claims_checker.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/a-novel-kit/jwt"
-	"github.com/a-novel-kit/jwt/jwa"
+	"github.com/a-novel-kit/jwt/v2"
+	"github.com/a-novel-kit/jwt/v2/jwa"
 )
 
 // ErrInvalidClaims wraps every failure reported by a claims check, so callers can detect a rejected

--- a/jwp/claims_checker_test.go
+++ b/jwp/claims_checker_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/a-novel-kit/jwt"
-	"github.com/a-novel-kit/jwt/jwp"
+	"github.com/a-novel-kit/jwt/v2"
+	"github.com/a-novel-kit/jwt/v2/jwp"
 )
 
 func TestClaimsChecker(t *testing.T) {

--- a/jwp/key_embedder.go
+++ b/jwp/key_embedder.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/a-novel-kit/jwt/jwa"
-	"github.com/a-novel-kit/jwt/jwk"
+	"github.com/a-novel-kit/jwt/v2/jwa"
+	"github.com/a-novel-kit/jwt/v2/jwk"
 )
 
 // An EmbedKeyConfig configures how an [EmbedKey] advertises the signing key in a token's header: by

--- a/jwp/key_embedder_test.go
+++ b/jwp/key_embedder_test.go
@@ -5,10 +5,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/a-novel-kit/jwt/jwa"
-	"github.com/a-novel-kit/jwt/jwk"
-	"github.com/a-novel-kit/jwt/jwp"
-	"github.com/a-novel-kit/jwt/testutils"
+	"github.com/a-novel-kit/jwt/v2/jwa"
+	"github.com/a-novel-kit/jwt/v2/jwk"
+	"github.com/a-novel-kit/jwt/v2/jwp"
+	"github.com/a-novel-kit/jwt/v2/testutils"
 )
 
 func TestKeyEmbedder(t *testing.T) {

--- a/jws/assertions.go
+++ b/jws/assertions.go
@@ -1,6 +1,6 @@
 package jws
 
-import "github.com/a-novel-kit/jwt"
+import "github.com/a-novel-kit/jwt/v2"
 
 // Compile-time checks that every signer and verifier satisfies the plugin contract it is wired in
 // as. A signature drift is then caught at build time rather than at a call site (or, worse, only

--- a/jws/common.go
+++ b/jws/common.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/a-novel-kit/jwt"
+	"github.com/a-novel-kit/jwt/v2"
 )
 
 // ErrInvalidSignature is returned by a verifier when a token's signature does not match its header

--- a/jws/ecdsa.go
+++ b/jws/ecdsa.go
@@ -10,9 +10,9 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/a-novel-kit/jwt"
-	"github.com/a-novel-kit/jwt/jwa"
-	"github.com/a-novel-kit/jwt/jwk"
+	"github.com/a-novel-kit/jwt/v2"
+	"github.com/a-novel-kit/jwt/v2/jwa"
+	"github.com/a-novel-kit/jwt/v2/jwk"
 )
 
 // An ECDSAPreset bundles the curve, hash, and algorithm identifier for one ECDSA signing scheme.

--- a/jws/ecdsa_test.go
+++ b/jws/ecdsa_test.go
@@ -8,10 +8,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/a-novel-kit/jwt"
-	"github.com/a-novel-kit/jwt/jwk"
-	"github.com/a-novel-kit/jwt/jws"
-	"github.com/a-novel-kit/jwt/testutils"
+	"github.com/a-novel-kit/jwt/v2"
+	"github.com/a-novel-kit/jwt/v2/jwk"
+	"github.com/a-novel-kit/jwt/v2/jws"
+	"github.com/a-novel-kit/jwt/v2/testutils"
 )
 
 func TestECDSA(t *testing.T) {

--- a/jws/ed25519.go
+++ b/jws/ed25519.go
@@ -6,9 +6,9 @@ import (
 	"encoding/base64"
 	"fmt"
 
-	"github.com/a-novel-kit/jwt"
-	"github.com/a-novel-kit/jwt/jwa"
-	"github.com/a-novel-kit/jwt/jwk"
+	"github.com/a-novel-kit/jwt/v2"
+	"github.com/a-novel-kit/jwt/v2/jwa"
+	"github.com/a-novel-kit/jwt/v2/jwk"
 )
 
 // An ED25519Signer signs tokens with the Ed25519 EdDSA scheme as a [jwt.ProducerPlugin]. Build one

--- a/jws/ed25519_test.go
+++ b/jws/ed25519_test.go
@@ -8,10 +8,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/a-novel-kit/jwt"
-	"github.com/a-novel-kit/jwt/jwk"
-	"github.com/a-novel-kit/jwt/jws"
-	"github.com/a-novel-kit/jwt/testutils"
+	"github.com/a-novel-kit/jwt/v2"
+	"github.com/a-novel-kit/jwt/v2/jwk"
+	"github.com/a-novel-kit/jwt/v2/jws"
+	"github.com/a-novel-kit/jwt/v2/testutils"
 )
 
 func TestED25519(t *testing.T) {

--- a/jws/hmac.go
+++ b/jws/hmac.go
@@ -7,9 +7,9 @@ import (
 	"encoding/base64"
 	"fmt"
 
-	"github.com/a-novel-kit/jwt"
-	"github.com/a-novel-kit/jwt/jwa"
-	"github.com/a-novel-kit/jwt/jwk"
+	"github.com/a-novel-kit/jwt/v2"
+	"github.com/a-novel-kit/jwt/v2/jwa"
+	"github.com/a-novel-kit/jwt/v2/jwk"
 )
 
 // An HMACPreset bundles the hash and algorithm identifier for one HMAC signing scheme. Pass one of

--- a/jws/hmac_test.go
+++ b/jws/hmac_test.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/a-novel-kit/jwt"
-	"github.com/a-novel-kit/jwt/jwk"
-	"github.com/a-novel-kit/jwt/jws"
-	"github.com/a-novel-kit/jwt/testutils"
+	"github.com/a-novel-kit/jwt/v2"
+	"github.com/a-novel-kit/jwt/v2/jwk"
+	"github.com/a-novel-kit/jwt/v2/jws"
+	"github.com/a-novel-kit/jwt/v2/testutils"
 )
 
 func TestHMAC(t *testing.T) {

--- a/jws/insecure.go
+++ b/jws/insecure.go
@@ -5,8 +5,8 @@ import (
 	"encoding/base64"
 	"fmt"
 
-	"github.com/a-novel-kit/jwt"
-	"github.com/a-novel-kit/jwt/jwa"
+	"github.com/a-novel-kit/jwt/v2"
+	"github.com/a-novel-kit/jwt/v2/jwa"
 )
 
 // An InsecureVerifier decodes a token's payload without checking its signature. It accepts any

--- a/jws/insecure_test.go
+++ b/jws/insecure_test.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/a-novel-kit/jwt"
-	"github.com/a-novel-kit/jwt/jwa"
-	"github.com/a-novel-kit/jwt/jwk"
-	"github.com/a-novel-kit/jwt/jws"
+	"github.com/a-novel-kit/jwt/v2"
+	"github.com/a-novel-kit/jwt/v2/jwa"
+	"github.com/a-novel-kit/jwt/v2/jwk"
+	"github.com/a-novel-kit/jwt/v2/jws"
 )
 
 func TestInsecure(t *testing.T) {

--- a/jws/keyfloor_test.go
+++ b/jws/keyfloor_test.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/a-novel-kit/jwt"
-	"github.com/a-novel-kit/jwt/jwa"
-	"github.com/a-novel-kit/jwt/jws"
+	"github.com/a-novel-kit/jwt/v2"
+	"github.com/a-novel-kit/jwt/v2/jwa"
+	"github.com/a-novel-kit/jwt/v2/jws"
 )
 
 // smallRSAKey is a bogus RSA key with a sub-2048-bit modulus. It is enough to exercise the key-size

--- a/jws/rsa.go
+++ b/jws/rsa.go
@@ -9,9 +9,9 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/a-novel-kit/jwt"
-	"github.com/a-novel-kit/jwt/jwa"
-	"github.com/a-novel-kit/jwt/jwk"
+	"github.com/a-novel-kit/jwt/v2"
+	"github.com/a-novel-kit/jwt/v2/jwa"
+	"github.com/a-novel-kit/jwt/v2/jwk"
 )
 
 // An RSAPreset bundles the hash and algorithm identifier for one RSASSA-PKCS1-v1_5 signing scheme.

--- a/jws/rsa_pss.go
+++ b/jws/rsa_pss.go
@@ -9,9 +9,9 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/a-novel-kit/jwt"
-	"github.com/a-novel-kit/jwt/jwa"
-	"github.com/a-novel-kit/jwt/jwk"
+	"github.com/a-novel-kit/jwt/v2"
+	"github.com/a-novel-kit/jwt/v2/jwa"
+	"github.com/a-novel-kit/jwt/v2/jwk"
 )
 
 // An RSAPSSPreset bundles the hash and algorithm identifier for one RSASSA-PSS signing scheme.

--- a/jws/rsa_pss_test.go
+++ b/jws/rsa_pss_test.go
@@ -8,10 +8,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/a-novel-kit/jwt"
-	"github.com/a-novel-kit/jwt/jwk"
-	"github.com/a-novel-kit/jwt/jws"
-	"github.com/a-novel-kit/jwt/testutils"
+	"github.com/a-novel-kit/jwt/v2"
+	"github.com/a-novel-kit/jwt/v2/jwk"
+	"github.com/a-novel-kit/jwt/v2/jws"
+	"github.com/a-novel-kit/jwt/v2/testutils"
 )
 
 func TestRSAPSS(t *testing.T) {

--- a/jws/rsa_test.go
+++ b/jws/rsa_test.go
@@ -8,10 +8,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/a-novel-kit/jwt"
-	"github.com/a-novel-kit/jwt/jwk"
-	"github.com/a-novel-kit/jwt/jws"
-	"github.com/a-novel-kit/jwt/testutils"
+	"github.com/a-novel-kit/jwt/v2"
+	"github.com/a-novel-kit/jwt/v2/jwk"
+	"github.com/a-novel-kit/jwt/v2/jws"
+	"github.com/a-novel-kit/jwt/v2/testutils"
 )
 
 func TestRSA(t *testing.T) {

--- a/jws/sourced.go
+++ b/jws/sourced.go
@@ -5,9 +5,9 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/a-novel-kit/jwt"
-	"github.com/a-novel-kit/jwt/jwa"
-	"github.com/a-novel-kit/jwt/jwk"
+	"github.com/a-novel-kit/jwt/v2"
+	"github.com/a-novel-kit/jwt/v2/jwa"
+	"github.com/a-novel-kit/jwt/v2/jwk"
 )
 
 // verifyFromSource tries each key the source lists, honoring a KID hint, until one verifies the

--- a/producer_claims.go
+++ b/producer_claims.go
@@ -8,7 +8,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/samber/lo"
 
-	"github.com/a-novel-kit/jwt/jwa"
+	"github.com/a-novel-kit/jwt/v2/jwa"
 )
 
 // TargetConfig scopes a set of claims to an intended context. Recording where a token comes from

--- a/producer_claims_test.go
+++ b/producer_claims_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/a-novel-kit/jwt"
+	"github.com/a-novel-kit/jwt/v2"
 )
 
 func TestNewBasicClaims(t *testing.T) {

--- a/producer_header.go
+++ b/producer_header.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/a-novel-kit/jwt/jwa"
+	"github.com/a-novel-kit/jwt/v2/jwa"
 )
 
 // HeaderProducerConfig describes the base JOSE header stamped onto every token: its media types,

--- a/producer_header_test.go
+++ b/producer_header_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/a-novel-kit/jwt"
-	"github.com/a-novel-kit/jwt/jwa"
+	"github.com/a-novel-kit/jwt/v2"
+	"github.com/a-novel-kit/jwt/v2/jwa"
 )
 
 func TestNewBasicHeaderProducer(t *testing.T) {

--- a/producer_plugin.go
+++ b/producer_plugin.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 
-	"github.com/a-novel-kit/jwt/jwa"
+	"github.com/a-novel-kit/jwt/v2/jwa"
 )
 
 var (

--- a/producer_test.go
+++ b/producer_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/a-novel-kit/jwt"
-	"github.com/a-novel-kit/jwt/jwa"
+	"github.com/a-novel-kit/jwt/v2"
+	"github.com/a-novel-kit/jwt/v2/jwa"
 )
 
 type fakeProducerPlugin struct {

--- a/recipient.go
+++ b/recipient.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/a-novel-kit/jwt/jwa"
+	"github.com/a-novel-kit/jwt/v2/jwa"
 )
 
 // DefaultMaxTokenBytes bounds the size of an untrusted token Consume will parse when the

--- a/recipient_plugin.go
+++ b/recipient_plugin.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/a-novel-kit/jwt/jwa"
+	"github.com/a-novel-kit/jwt/v2/jwa"
 )
 
 // ErrMismatchRecipientPlugin is returned by a plugin that does not recognize a token, signaling

--- a/recipient_test.go
+++ b/recipient_test.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/a-novel-kit/jwt"
-	"github.com/a-novel-kit/jwt/jwa"
+	"github.com/a-novel-kit/jwt/v2"
+	"github.com/a-novel-kit/jwt/v2/jwa"
 )
 
 type fakeRecipientPlugin struct {

--- a/testutils/jwk.go
+++ b/testutils/jwk.go
@@ -7,8 +7,8 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/a-novel-kit/jwt/jwa"
-	"github.com/a-novel-kit/jwt/jwk"
+	"github.com/a-novel-kit/jwt/v2/jwa"
+	"github.com/a-novel-kit/jwt/v2/jwk"
 )
 
 // NewStaticKeysSource returns a [jwk.Source] backed by a fixed, in-memory set of keys, so a test can

--- a/token_test.go
+++ b/token_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/a-novel-kit/jwt"
+	"github.com/a-novel-kit/jwt/v2"
 )
 
 func TestRawToken(t *testing.T) {


### PR DESCRIPTION
## Summary

Task #443 of Epic #431 — the **foundational** change for the v2.0.0 line, targeting the `v2` branch.

Go's semantic import versioning requires a `/v2` suffix on the module path for major version 2 (two paths differing only in major version are distinct packages to the compiler). This:

- Sets `go.mod` module to `github.com/a-novel-kit/jwt/v2`.
- Rewrites all internal imports across ~86 files to the `/v2` path (e.g. `github.com/a-novel-kit/jwt/v2/jwe`).
- Updates the README install command + intro to `/v2`.

Package names are unchanged — only the import *path* gains `/v2`.

## Branching

Base is **`v2`** (a copy of master), per the agreed strategy: `master` stays clean v1 during development; at the end `v2` becomes `master` and current `master` is renamed `v1`, and v2.0.0 is tagged. v1 consumers keep resolving `@v1.3.0` from the tag. Consumers migrate import paths when they adopt v2.0.0.

## Breaking changes

**Yes** — the import path changes. Documented in the commit's `BREAKING CHANGE` footer. This is expected for a v2 line and carries no runtime behavior change on its own.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go test ./...` all pass on the new module path (every package now reports as `.../jwt/v2/...`).

Closes #443