### PR TITLE
feat!: aud as string-or-array with membership check (C1)

### DIFF
--- a/jwa/audience.go
+++ b/jwa/audience.go
@@ -1,0 +1,51 @@
+package jwa
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// Audience is the "aud" claim (RFC 7519 §4.1.3): the recipients a token is intended for. It is an
+// array of strings, but the single-audience case serializes as a bare string — the special case the
+// RFC allows and that most producers emit — so one-audience tokens stay compatible with peers that
+// expect a plain string.
+type Audience []string
+
+// MarshalJSON emits a bare string for a single audience and an array otherwise.
+func (aud Audience) MarshalJSON() ([]byte, error) {
+	if len(aud) == 1 {
+		return json.Marshal(aud[0])
+	}
+
+	return json.Marshal([]string(aud))
+}
+
+// UnmarshalJSON accepts both the array form and the single-string special case.
+func (aud *Audience) UnmarshalJSON(data []byte) error {
+	if bytes.Equal(bytes.TrimSpace(data), []byte("null")) {
+		*aud = nil
+
+		return nil
+	}
+
+	// Try the single-string form first; fall back to the array form on a type error.
+	var single string
+
+	err := json.Unmarshal(data, &single)
+	if err == nil {
+		*aud = Audience{single}
+
+		return nil
+	}
+
+	var many []string
+
+	err = json.Unmarshal(data, &many)
+	if err != nil {
+		return err
+	}
+
+	*aud = many
+
+	return nil
+}

--- a/jwa/audience.go
+++ b/jwa/audience.go
@@ -11,16 +11,24 @@ import (
 // expect a plain string.
 type Audience []string
 
-// MarshalJSON emits a bare string for a single audience and an array otherwise.
+// MarshalJSON emits a bare string for a single audience and a (possibly empty) array otherwise.
 func (aud Audience) MarshalJSON() ([]byte, error) {
 	if len(aud) == 1 {
 		return json.Marshal(aud[0])
 	}
 
+	// A nil slice marshals to null; emit [] instead so the "array otherwise" contract holds. As an
+	// omitempty field an empty audience is omitted entirely, so this is only reached on direct
+	// marshaling.
+	if len(aud) == 0 {
+		return []byte("[]"), nil
+	}
+
 	return json.Marshal([]string(aud))
 }
 
-// UnmarshalJSON accepts both the array form and the single-string special case.
+// UnmarshalJSON accepts the array form, the single-string special case, and JSON null (which yields
+// a nil Audience).
 func (aud *Audience) UnmarshalJSON(data []byte) error {
 	if bytes.Equal(bytes.TrimSpace(data), []byte("null")) {
 		*aud = nil

--- a/jwa/audience_test.go
+++ b/jwa/audience_test.go
@@ -1,0 +1,59 @@
+package jwa_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/a-novel-kit/jwt/v2/jwa"
+)
+
+func TestAudienceMarshal(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+		aud  jwa.Audience
+		want string
+	}{
+		{"Single", jwa.Audience{"a"}, `"a"`},
+		{"Multiple", jwa.Audience{"a", "b"}, `["a","b"]`},
+		{"Empty", jwa.Audience{}, `[]`},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := json.Marshal(testCase.aud)
+			require.NoError(t, err)
+			require.Equal(t, testCase.want, string(got))
+		})
+	}
+}
+
+func TestAudienceUnmarshal(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+		raw  string
+		want jwa.Audience
+	}{
+		{"String", `"a"`, jwa.Audience{"a"}},
+		{"Array", `["a","b"]`, jwa.Audience{"a", "b"}},
+		{"Null", `null`, nil},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			var aud jwa.Audience
+
+			require.NoError(t, json.Unmarshal([]byte(testCase.raw), &aud))
+			require.Equal(t, testCase.want, aud)
+		})
+	}
+}

--- a/jwa/audience_test.go
+++ b/jwa/audience_test.go
@@ -20,6 +20,7 @@ func TestAudienceMarshal(t *testing.T) {
 		{"Single", jwa.Audience{"a"}, `"a"`},
 		{"Multiple", jwa.Audience{"a", "b"}, `["a","b"]`},
 		{"Empty", jwa.Audience{}, `[]`},
+		{"Nil", nil, `[]`},
 	}
 
 	for _, testCase := range testCases {

--- a/jwa/jwh.go
+++ b/jwa/jwh.go
@@ -86,8 +86,8 @@ type JWHCommon struct {
 	Iss string `json:"iss,omitempty"`
 	// Sub mirrors the payload's subject claim.
 	Sub string `json:"sub,omitempty"`
-	// Aud mirrors the payload's audience claim.
-	Aud string `json:"aud,omitempty"`
+	// Aud mirrors the payload's audience claim. It is a string or an array of strings.
+	Aud Audience `json:"aud,omitempty"`
 }
 
 // JWHEmbeddedKey carries the header parameters that reference or embed the key

--- a/jwa/jwt.go
+++ b/jwa/jwt.go
@@ -20,9 +20,10 @@ type ClaimsCommon struct {
 	// https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.2
 	Sub string `json:"sub,omitempty"`
 	// Aud identifies the recipients the token is intended for. A recipient that
-	// does not find itself in the audience rejects the token.
+	// does not find itself in the audience rejects the token. It is a string or
+	// an array of strings.
 	// https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3
-	Aud string `json:"aud,omitempty"`
+	Aud Audience `json:"aud,omitempty"`
 
 	// Exp is the time on or after which the token must not be accepted, as a
 	// Unix timestamp in seconds.

--- a/jwp/claims_checker.go
+++ b/jwp/claims_checker.go
@@ -42,9 +42,12 @@ func NewClaimsCheckTarget(target jwt.TargetConfig) *ClaimsCheckTarget {
 }
 
 func (claimsCheck *ClaimsCheckTarget) CheckClaims(claims *jwa.Claims) error {
-	if claimsCheck.target.Audience != claims.Aud {
+	// RFC 7519 §4.1.3: the recipient identifies with a value in the token's audience. The check
+	// passes when any configured audience appears in the token's aud; an empty target audience opts
+	// out of the check (matching go-jose / golang-jwt).
+	if len(claimsCheck.target.Audience) > 0 && !audienceContainsAny(claims.Aud, claimsCheck.target.Audience) {
 		return fmt.Errorf(
-			"invalid audience %s, expected %s",
+			"invalid audience %v, expected one of %v",
 			claims.Aud, claimsCheck.target.Audience,
 		)
 	}
@@ -64,6 +67,20 @@ func (claimsCheck *ClaimsCheckTarget) CheckClaims(claims *jwa.Claims) error {
 	}
 
 	return nil
+}
+
+// audienceContainsAny reports whether have and want share at least one value — the token names an
+// audience the recipient answers to.
+func audienceContainsAny(have, want jwa.Audience) bool {
+	for _, w := range want {
+		for _, h := range have {
+			if w == h {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 // A ClaimsCheckTimestamp rejects a token that has expired or is not yet valid, comparing the "exp"

--- a/jwp/claims_checker_test.go
+++ b/jwp/claims_checker_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/a-novel-kit/jwt/v2"
+	"github.com/a-novel-kit/jwt/v2/jwa"
 	"github.com/a-novel-kit/jwt/v2/jwp"
 )
 
@@ -47,7 +48,7 @@ func TestClaimsChecker(t *testing.T) {
 			config: &jwp.ClaimsCheckerConfig{
 				Checks: []jwp.ClaimsCheck{
 					jwp.NewClaimsCheckTarget(jwt.TargetConfig{
-						Audience: "audience",
+						Audience: jwa.Audience{"audience"},
 						Issuer:   "issuer",
 						Subject:  "subject",
 					}),
@@ -76,7 +77,7 @@ func TestClaimsChecker(t *testing.T) {
 			config: &jwp.ClaimsCheckerConfig{
 				Checks: []jwp.ClaimsCheck{
 					jwp.NewClaimsCheckTarget(jwt.TargetConfig{
-						Audience: "audience",
+						Audience: jwa.Audience{"audience"},
 						Issuer:   "issuer",
 						Subject:  "subject",
 					}),
@@ -101,7 +102,7 @@ func TestClaimsChecker(t *testing.T) {
 			config: &jwp.ClaimsCheckerConfig{
 				Checks: []jwp.ClaimsCheck{
 					jwp.NewClaimsCheckTarget(jwt.TargetConfig{
-						Audience: "audience",
+						Audience: jwa.Audience{"audience"},
 						Issuer:   "issuer",
 						Subject:  "subject",
 					}),
@@ -126,7 +127,7 @@ func TestClaimsChecker(t *testing.T) {
 			config: &jwp.ClaimsCheckerConfig{
 				Checks: []jwp.ClaimsCheck{
 					jwp.NewClaimsCheckTarget(jwt.TargetConfig{
-						Audience: "audience",
+						Audience: jwa.Audience{"audience"},
 						Issuer:   "issuer",
 						Subject:  "subject",
 					}),
@@ -345,4 +346,21 @@ func TestClaimsCheckerNilDeserializer(t *testing.T) {
 
 	require.NoError(t, checker.Unmarshal([]byte(`{"foo":"bar"}`), &dst))
 	require.Equal(t, map[string]any{"foo": "bar"}, dst)
+}
+
+func TestClaimsCheckTargetAudienceMembership(t *testing.T) {
+	t.Parallel()
+
+	// A token addressed to several audiences: a recipient passes iff it names one of them.
+	claims := &jwa.Claims{ClaimsCommon: jwa.ClaimsCommon{Aud: jwa.Audience{"svc-a", "svc-b"}}}
+
+	member := jwp.NewClaimsCheckTarget(jwt.TargetConfig{Audience: jwa.Audience{"svc-b"}})
+	require.NoError(t, member.CheckClaims(claims))
+
+	stranger := jwp.NewClaimsCheckTarget(jwt.TargetConfig{Audience: jwa.Audience{"svc-c"}})
+	require.Error(t, stranger.CheckClaims(claims))
+
+	// An empty target audience opts out of the check.
+	optOut := jwp.NewClaimsCheckTarget(jwt.TargetConfig{})
+	require.NoError(t, optOut.CheckClaims(claims))
 }

--- a/producer_claims.go
+++ b/producer_claims.go
@@ -16,8 +16,10 @@ import (
 type TargetConfig struct {
 	// Issuer that produced the token. A recipient should accept only tokens from producers it trusts.
 	Issuer string
-	// Audience the token is meant for. A recipient should reject tokens addressed elsewhere.
-	Audience string
+	// Audience the token is meant for (RFC 7519 §4.1.3). On a producer it sets the token's aud; in a
+	// recipient check it is the identities to match — the token must name at least one. Empty opts
+	// out of the audience check.
+	Audience jwa.Audience
 	// Subject the token describes. A recipient should reject tokens issued for a different subject.
 	Subject string
 }

--- a/producer_claims_test.go
+++ b/producer_claims_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/a-novel-kit/jwt/v2"
+	"github.com/a-novel-kit/jwt/v2/jwa"
 )
 
 func TestNewBasicClaims(t *testing.T) {
@@ -54,7 +55,7 @@ func TestNewBasicClaims(t *testing.T) {
 			TargetConfig: jwt.TargetConfig{
 				Issuer:   "issuer",
 				Subject:  "subject",
-				Audience: "audience",
+				Audience: jwa.Audience{"audience"},
 			},
 		})
 		require.NoError(t, err)
@@ -65,7 +66,7 @@ func TestNewBasicClaims(t *testing.T) {
 
 		require.Equal(t, "issuer", claims.Iss)
 		require.Equal(t, "subject", claims.Sub)
-		require.Equal(t, "audience", claims.Aud)
+		require.Equal(t, jwa.Audience{"audience"}, claims.Aud)
 
 		require.Empty(t, claims.Exp)
 	})

--- a/producer_header_test.go
+++ b/producer_header_test.go
@@ -35,7 +35,7 @@ func TestNewBasicHeaderProducer(t *testing.T) {
 				TargetConfig: jwt.TargetConfig{
 					Issuer:   "issuer",
 					Subject:  "subject",
-					Audience: "audience",
+					Audience: jwa.Audience{"audience"},
 				},
 			},
 			expect: `{"alg":"none","typ":"JOSE","cty":"JWT","iss":"issuer","sub":"subject","aud":"audience"}`,


### PR DESCRIPTION
## Summary

Task #427 of Epic #431 (v2.0.0), targeting `v2`. RFC 7519 §4.1.3 compliance for the `aud` claim.

- **`jwa.Audience` type** (`[]string`) with custom marshal/unmarshal: accepts a string **or** an array; serializes a single audience as a bare string (the RFC special case) and multiple as an array.
- **Retype** `jwa.Claims.Aud`, `jwa.JWH.Aud`, and `jwt.TargetConfig.Audience` from `string` to `jwa.Audience`.
- **Membership check**: `ClaimsCheckTarget` now passes when the token names at least one configured audience (overlap), not on exact equality. An empty target audience opts out of the check (matching go-jose / golang-jwt).

## Breaking changes

**Yes.** The three fields change type `string` → `jwa.Audience`. The **wire format is unchanged** for the common single-audience case (still a bare string), so tokens interoperate; Go callers update field literals (`Audience: "x"` → `Audience: jwa.Audience{"x"}`). Empty-target audience behavior changes from "reject aud-bearing tokens" to "skip the check." `BREAKING CHANGE` footer on the commit.

**Cross-org consumers** (`service-authentication`, `service-json-keys`) update their `TargetConfig.Audience` literals — sequenced by `manage-versions`.

## Test plan

- [x] `go test ./...` passes. New tests: `Audience` marshal/unmarshal round-trips (string, array, null); multi-audience membership (recipient in aud passes, stranger fails, empty target opts out). Existing single-audience checks still pass.

Closes #427