### PR TITLE
refactor!: naming consistency — Sourced* HMAC + PBES2 manager (M7)

### DIFF
--- a/jwe/jwek/assertions.go
+++ b/jwe/jwek/assertions.go
@@ -11,7 +11,7 @@ var (
 	_ jwe.CEKManager = (*DirectKeyManager)(nil)
 	_ jwe.CEKManager = (*ECDHKeyAgrManager)(nil)
 	_ jwe.CEKManager = (*ECDHKeyAgrKWManager)(nil)
-	_ jwe.CEKManager = (*PBES2KeyEncKWConfig)(nil)
+	_ jwe.CEKManager = (*PBES2KeyEncKWManager)(nil)
 	_ jwe.CEKManager = (*AESKWManager)(nil)
 
 	_ jwe.CEKDecoder = (*AESGCMKWDecoder)(nil)

--- a/jwe/jwek/pbes2_key_enc.go
+++ b/jwe/jwek/pbes2_key_enc.go
@@ -60,10 +60,10 @@ type PBES2KeyEncKWManagerConfig struct {
 	Secret string
 }
 
-// PBES2KeyEncKWConfig implements jwe.CEKManager: it derives a wrap key from a
+// PBES2KeyEncKWManager implements jwe.CEKManager: it derives a wrap key from a
 // password with PBES2 (PBKDF2) and wraps the content encryption key with AES Key
 // Wrap.
-type PBES2KeyEncKWConfig struct {
+type PBES2KeyEncKWManager struct {
 	config PBES2KeyEncKWManagerConfig
 
 	alg     jwa.Alg
@@ -77,8 +77,8 @@ type PBES2KeyEncKWConfig struct {
 // PBES2KeyEncKWPreset values (for example PBES2A128KW).
 //
 // https://datatracker.ietf.org/doc/html/rfc7518#section-4.8
-func NewPBES2KeyEncKWManager(config *PBES2KeyEncKWManagerConfig, preset PBES2KeyEncKWPreset) *PBES2KeyEncKWConfig {
-	return &PBES2KeyEncKWConfig{
+func NewPBES2KeyEncKWManager(config *PBES2KeyEncKWManagerConfig, preset PBES2KeyEncKWPreset) *PBES2KeyEncKWManager {
+	return &PBES2KeyEncKWManager{
 		config:  *config,
 		alg:     preset.Alg,
 		hash:    preset.Hash,
@@ -86,9 +86,9 @@ func NewPBES2KeyEncKWManager(config *PBES2KeyEncKWManagerConfig, preset PBES2Key
 	}
 }
 
-func (manager *PBES2KeyEncKWConfig) SetHeader(_ context.Context, header *jwa.JWH) (*jwa.JWH, error) {
+func (manager *PBES2KeyEncKWManager) SetHeader(_ context.Context, header *jwa.JWH) (*jwa.JWH, error) {
 	if !header.Alg.Empty() {
-		return nil, fmt.Errorf("(PBES2KeyEncKWConfig.SetHeader) %w: alg field already set", jwt.ErrConflictingHeader)
+		return nil, fmt.Errorf("(PBES2KeyEncKWManager.SetHeader) %w: alg field already set", jwt.ErrConflictingHeader)
 	}
 
 	// A fresh salt per token widens the key space so the same password never
@@ -97,7 +97,7 @@ func (manager *PBES2KeyEncKWConfig) SetHeader(_ context.Context, header *jwa.JWH
 
 	_, err := rand.Read(salt)
 	if err != nil {
-		return nil, fmt.Errorf("(PBES2KeyEncKWConfig.SetHeader) generate salt: %w", err)
+		return nil, fmt.Errorf("(PBES2KeyEncKWManager.SetHeader) generate salt: %w", err)
 	}
 
 	header.JWHPBES2 = jwa.JWHPBES2{
@@ -109,11 +109,11 @@ func (manager *PBES2KeyEncKWConfig) SetHeader(_ context.Context, header *jwa.JWH
 	return header, nil
 }
 
-func (manager *PBES2KeyEncKWConfig) ComputeCEK(_ context.Context, _ *jwa.JWH) ([]byte, error) {
+func (manager *PBES2KeyEncKWManager) ComputeCEK(_ context.Context, _ *jwa.JWH) ([]byte, error) {
 	return manager.config.CEK, nil
 }
 
-func (manager *PBES2KeyEncKWConfig) EncryptCEK(_ context.Context, header *jwa.JWH, cek []byte) ([]byte, error) {
+func (manager *PBES2KeyEncKWManager) EncryptCEK(_ context.Context, header *jwa.JWH, cek []byte) ([]byte, error) {
 	wrapKey := pbkdf2.Key(
 		[]byte(manager.config.Secret),
 		[]byte(header.P2S),
@@ -124,12 +124,12 @@ func (manager *PBES2KeyEncKWConfig) EncryptCEK(_ context.Context, header *jwa.JW
 
 	block, err := aes.NewCipher(wrapKey)
 	if err != nil {
-		return nil, fmt.Errorf("(PBES2KeyEncKWConfig.EncryptCEK) create cipher: %w", err)
+		return nil, fmt.Errorf("(PBES2KeyEncKWManager.EncryptCEK) create cipher: %w", err)
 	}
 
 	wrapped, err := internal.KeyWrap(block, cek)
 	if err != nil {
-		return nil, fmt.Errorf("(PBES2KeyEncKWConfig.EncryptCEK) wrap key: %w", err)
+		return nil, fmt.Errorf("(PBES2KeyEncKWManager.EncryptCEK) wrap key: %w", err)
 	}
 
 	return wrapped, nil

--- a/jwe/jwek/pbes2_key_enc_test.go
+++ b/jwe/jwek/pbes2_key_enc_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/a-novel-kit/jwt/v2"
 	"github.com/a-novel-kit/jwt/v2/jwa"
 	"github.com/a-novel-kit/jwt/v2/jwe/jwek"
 	"github.com/a-novel-kit/jwt/v2/jwk"
@@ -115,4 +116,32 @@ func TestPBES2KeyEncKW(t *testing.T) {
 			})
 		})
 	}
+}
+
+func TestPBES2KeyEncKWSetHeaderConflict(t *testing.T) {
+	t.Parallel()
+
+	manager := jwek.NewPBES2KeyEncKWManager(&jwek.PBES2KeyEncKWManagerConfig{
+		Iterations: 1000,
+		SaltSize:   16,
+		CEK:        make([]byte, 32),
+		Secret:     "password",
+	}, jwek.PBES2A256KW)
+
+	// SetHeader refuses to overwrite an algorithm already stamped on the header.
+	_, err := manager.SetHeader(t.Context(), &jwa.JWH{JWHCommon: jwa.JWHCommon{Alg: jwa.RS256}})
+	require.ErrorIs(t, err, jwt.ErrConflictingHeader)
+}
+
+func TestPBES2KeyEncKWDecoderAlgMismatch(t *testing.T) {
+	t.Parallel()
+
+	decoder := jwek.NewPBES2KeyEncKWDecoder(
+		&jwek.PBES2KeyEncKWDecoderConfig{Secret: "password"},
+		jwek.PBES2A256KW,
+	)
+
+	// The decoder rejects a token whose alg is not the one it manages.
+	_, err := decoder.ComputeCEK(t.Context(), &jwa.JWH{JWHCommon: jwa.JWHCommon{Alg: jwa.RS256}}, []byte("enc"))
+	require.Error(t, err)
 }

--- a/jws/assertions.go
+++ b/jws/assertions.go
@@ -7,7 +7,7 @@ import "github.com/a-novel-kit/jwt/v2"
 // once a caller tries to use it — as happened for a CEK manager before these guards existed).
 var (
 	_ jwt.ProducerPlugin = (*HMACSigner)(nil)
-	_ jwt.ProducerPlugin = (*SourceHMACSigner)(nil)
+	_ jwt.ProducerPlugin = (*SourcedHMACSigner)(nil)
 	_ jwt.ProducerPlugin = (*RSASigner)(nil)
 	_ jwt.ProducerPlugin = (*SourcedRSASigner)(nil)
 	_ jwt.ProducerPlugin = (*ECDSASigner)(nil)
@@ -16,7 +16,7 @@ var (
 	_ jwt.ProducerPlugin = (*SourcedED25519Signer)(nil)
 
 	_ jwt.RecipientPlugin = (*HMACVerifier)(nil)
-	_ jwt.RecipientPlugin = (*SourceHMACVerifier)(nil)
+	_ jwt.RecipientPlugin = (*SourcedHMACVerifier)(nil)
 	_ jwt.RecipientPlugin = (*RSAVerifier)(nil)
 	_ jwt.RecipientPlugin = (*SourcedRSAVerifier)(nil)
 	_ jwt.RecipientPlugin = (*ECDSAVerifier)(nil)

--- a/jws/hmac.go
+++ b/jws/hmac.go
@@ -181,10 +181,10 @@ func sourcedHMACKey(alg jwa.Alg) keyDecoder[[]byte] {
 	}
 }
 
-// A SourceHMACSigner signs like an [HMACSigner] but resolves its secret from a [jwk.Source] at each
+// A SourcedHMACSigner signs like an [HMACSigner] but resolves its secret from a [jwk.Source] at each
 // call, so the plugin follows key rotation instead of pinning one secret. Build one with
 // [NewSourcedHMACSigner].
-type SourceHMACSigner struct {
+type SourcedHMACSigner struct {
 	source *jwk.Source
 	preset HMACPreset
 }
@@ -194,17 +194,17 @@ type SourceHMACSigner struct {
 // selects the hash.
 //
 // See RFC 7518, section 3.2: https://datatracker.ietf.org/doc/html/rfc7518#section-3.2
-func NewSourcedHMACSigner(source *jwk.Source, preset HMACPreset) *SourceHMACSigner {
-	return &SourceHMACSigner{
+func NewSourcedHMACSigner(source *jwk.Source, preset HMACPreset) *SourcedHMACSigner {
+	return &SourcedHMACSigner{
 		source: source,
 		preset: preset,
 	}
 }
 
-func (signer *SourceHMACSigner) Header(ctx context.Context, header *jwa.JWH) (*jwa.JWH, error) {
+func (signer *SourcedHMACSigner) Header(ctx context.Context, header *jwa.JWH) (*jwa.JWH, error) {
 	key, kid, err := signFromSource(ctx, signer.source, header.KID, sourcedHMACKey(signer.preset.Alg))
 	if err != nil {
-		return nil, fmt.Errorf("(SourceHMACSigner.Header) %w", err)
+		return nil, fmt.Errorf("(SourcedHMACSigner.Header) %w", err)
 	}
 
 	// Stamp the resolved key's ID into the header so recipients can select it for verification.
@@ -215,19 +215,19 @@ func (signer *SourceHMACSigner) Header(ctx context.Context, header *jwa.JWH) (*j
 	return NewHMACSigner(key, signer.preset).Header(ctx, header)
 }
 
-func (signer *SourceHMACSigner) Transform(ctx context.Context, header *jwa.JWH, rawToken string) (string, error) {
+func (signer *SourcedHMACSigner) Transform(ctx context.Context, header *jwa.JWH, rawToken string) (string, error) {
 	key, _, err := signFromSource(ctx, signer.source, header.KID, sourcedHMACKey(signer.preset.Alg))
 	if err != nil {
-		return "", fmt.Errorf("(SourceHMACSigner.Transform) %w", err)
+		return "", fmt.Errorf("(SourcedHMACSigner.Transform) %w", err)
 	}
 
 	return NewHMACSigner(key, signer.preset).Transform(ctx, header, rawToken)
 }
 
-// A SourceHMACVerifier verifies like an [HMACVerifier] but resolves candidate secrets from a
+// A SourcedHMACVerifier verifies like an [HMACVerifier] but resolves candidate secrets from a
 // [jwk.Source] at each call. When the token names a KID it tries only that secret; otherwise it
 // tries every secret in the source. Build one with [NewSourcedHMACVerifier].
-type SourceHMACVerifier struct {
+type SourcedHMACVerifier struct {
 	source *jwk.Source
 	preset HMACPreset
 }
@@ -236,14 +236,14 @@ type SourceHMACVerifier struct {
 // secrets drawn from the source. The preset (one of [HS256], [HS384], [HS512]) selects the hash.
 //
 // See RFC 7518, section 3.2: https://datatracker.ietf.org/doc/html/rfc7518#section-3.2
-func NewSourcedHMACVerifier(source *jwk.Source, preset HMACPreset) *SourceHMACVerifier {
-	return &SourceHMACVerifier{
+func NewSourcedHMACVerifier(source *jwk.Source, preset HMACPreset) *SourcedHMACVerifier {
+	return &SourcedHMACVerifier{
 		source: source,
 		preset: preset,
 	}
 }
 
-func (verifier *SourceHMACVerifier) Transform(ctx context.Context, header *jwa.JWH, rawToken string) ([]byte, error) {
+func (verifier *SourcedHMACVerifier) Transform(ctx context.Context, header *jwa.JWH, rawToken string) ([]byte, error) {
 	return verifyFromSource(ctx, verifier.source, header, rawToken, sourcedHMACKey(verifier.preset.Alg),
 		func(key []byte) jwt.RecipientPlugin {
 			return NewHMACVerifier(key, verifier.preset)

--- a/jws/hmac_test.go
+++ b/jws/hmac_test.go
@@ -301,3 +301,16 @@ func TestHMACSourcedVerifier(t *testing.T) {
 		})
 	}
 }
+
+func TestSourcedHMACSignerEmptySource(t *testing.T) {
+	t.Parallel()
+
+	// A sourced signer whose source holds no key fails instead of signing with nothing.
+	source := testutils.NewStaticKeysSource(t, []*jwk.Key[[]byte]{})
+	producer := jwt.NewProducer(jwt.ProducerConfig{
+		Plugins: []jwt.ProducerPlugin{jws.NewSourcedHMACSigner(source, jws.HS256)},
+	})
+
+	_, err := producer.Issue(t.Context(), map[string]any{"foo": "bar"}, nil)
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Summary

Task #441 of Epic #431 (v2.0.0), targeting `v2`. Two naming fixes:

- **`jws.SourceHMAC{Signer,Verifier}` → `jws.SourcedHMAC{Signer,Verifier}`** — every other sourced plugin is `Sourced<Family><Role>`; HMAC alone dropped the `d`. (Constructors were already `NewSourcedHMAC*`.)
- **`jwek.PBES2KeyEncKWConfig` → `jwek.PBES2KeyEncKWManager`** — `NewPBES2KeyEncKWManager` returned a type named `...Config`, but it's the `jwe.CEKManager` itself, not a config (the config is the separate, unchanged `PBES2KeyEncKWManagerConfig`).

## Ed25519 preset — decided against (was the 3rd scoped item)

On implementation I recommended, and the operator agreed, to **keep Ed25519 preset-free**. EdDSA is a parameterless algorithm (one curve, one hash, one alg), so a preset would be a single fixed `{Alg: EdDSA}` — pure ceremony. golang-jwt and go-jose both treat EdDSA without params; the simpler `NewED25519Signer(key)` shape reflects the algorithm's simplicity, not an inconsistency to paper over.

## Breaking changes

Two exported type renames (`BREAKING CHANGE` footers on each commit). No behavior change. No consumer (`service-json-keys`/`-authentication`) references these type names directly.

## Test plan

- [x] `go build ./...`, `go test ./...`, `gofmt` all green (renames only; existing suites cover the renamed types via their constructors).

Closes #441