### PR TITLE
docs: v2.0.0 migration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ responsibility.
 go get github.com/a-novel-kit/jwt/v2
 ```
 
+Upgrading across a major version? See the [migration guides](docs/migrations/README.md) — start
+with [Upgrading to v2.0.0](docs/migrations/v2.0.0.md).
+
 The root `jwt.Producer` and `jwt.Recipient` types handle the token lifecycle. With no plugins, they produce and consume
 raw JWT payloads with the `"none"` algorithm; this is useful for tests and trusted internal hops, but production tokens
 normally add JWS or JWE plugins.

--- a/docs/migrations/README.md
+++ b/docs/migrations/README.md
@@ -1,0 +1,8 @@
+# Migration guides
+
+Per-version upgrade guides, newest first. Each documents the **consumer action** a release
+requires — not a changelog. A release with no required action has no guide here.
+
+| Version | Guide |
+| --- | --- |
+| v2.0.0 | [Upgrading to v2.0.0](v2.0.0.md) — security hardening & API modernization (breaking) |

--- a/docs/migrations/README.md
+++ b/docs/migrations/README.md
@@ -3,6 +3,6 @@
 Per-version upgrade guides, newest first. Each documents the **consumer action** a release
 requires — not a changelog. A release with no required action has no guide here.
 
-| Version | Guide |
-| --- | --- |
-| v2.0.0 | [Upgrading to v2.0.0](v2.0.0.md) — security hardening & API modernization (breaking) |
+| Version | Guide                                                                                |
+| ------- | ------------------------------------------------------------------------------------ |
+| v2.0.0  | [Upgrading to v2.0.0](v2.0.0.md) — security hardening & API modernization (breaking) |

--- a/docs/migrations/v2.0.0.md
+++ b/docs/migrations/v2.0.0.md
@@ -121,12 +121,12 @@ preset names are unchanged.
 Only the symbols below changed name; behaviour is identical, and the constructors were already
 named correctly, so most call sites need no edit.
 
-| before | after |
-| --- | --- |
-| `jws.SourceHMACSigner` | `jws.SourcedHMACSigner` |
-| `jws.SourceHMACVerifier` | `jws.SourcedHMACVerifier` |
-| `jwek.PBES2KeyEncKWConfig` | `jwek.PBES2KeyEncKWManager` |
-| `jwek.AESKWPreset` · `AESGCMKWPreset` · `ECDHKeyAgrKWPreset` | `jwek.KeyWrapPreset` |
+| before                                                       | after                       |
+| ------------------------------------------------------------ | --------------------------- |
+| `jws.SourceHMACSigner`                                       | `jws.SourcedHMACSigner`     |
+| `jws.SourceHMACVerifier`                                     | `jws.SourcedHMACVerifier`   |
+| `jwek.PBES2KeyEncKWConfig`                                   | `jwek.PBES2KeyEncKWManager` |
+| `jwek.AESKWPreset` · `AESGCMKWPreset` · `ECDHKeyAgrKWPreset` | `jwek.KeyWrapPreset`        |
 
 The `jwek.KeyWrapPreset` instances (`A128KW`, `A128GCMKW`, `ECDHESA128KW`, …) keep their names and
 values — only the type unified.

--- a/docs/migrations/v2.0.0.md
+++ b/docs/migrations/v2.0.0.md
@@ -1,0 +1,141 @@
+# Upgrading to v2.0.0
+
+`v2.0.0` is the security-hardening and API-modernization release. The security fixes shipped
+non-breaking in `v1.3.0`; this release adds the breaking API cleanups `v1.3.0` could not.
+
+## Do I need to act?
+
+**Required.** Every consumer must update the import path to `/v2` and apply the API changes below.
+They are mechanical — renamed constructors, one claim-type change, and a reshaped key source. No
+token re-issuance is needed: the compact wire format and every algorithm behave identically. `v1.x`
+is not maintained going forward.
+
+## Update the import path to `/v2`
+
+Go requires a `/v2` suffix on the module path for major version 2 — two paths differing only in
+major version are distinct packages — so this is a hard prerequisite; nothing else compiles until
+it is done.
+
+```go
+// before
+import "github.com/a-novel-kit/jwt/jws"
+
+// after
+import "github.com/a-novel-kit/jwt/v2/jws"
+```
+
+```bash
+go get github.com/a-novel-kit/jwt/v2@v2.0.0
+# rewrite the imports across your module (run once):
+find . -name '*.go' -exec sed -i 's|github.com/a-novel-kit/jwt|github.com/a-novel-kit/jwt/v2|g' {} +
+go mod tidy
+```
+
+Package names are unchanged — only the path gains `/v2`.
+
+## Read tokens unverified with `Recipient.DecodeUnverified`
+
+`jws.InsecureVerifier` is removed. Reading a token without checking its signature is now an
+explicit method, so it can no longer be dropped into a plugin chain where it would silently
+disable verification for every token.
+
+```go
+// before
+r := jwt.NewRecipient(jwt.RecipientConfig{Plugins: []jwt.RecipientPlugin{jws.NewInsecureVerifier()}})
+err := r.Consume(ctx, token, &claims)
+
+// after
+r := jwt.NewRecipient(jwt.RecipientConfig{})
+err := r.DecodeUnverified(token, &claims)
+```
+
+Removed: `jws.InsecureVerifier`, `jws.NewInsecureVerifier`. `DecodeUnverified` returns an
+explicitly-untrusted result — never base a trust decision on it.
+
+## Set the audience as a `jwa.Audience`
+
+Per RFC 7519 §4.1.3, `aud` may be an array of strings. The fields change from `string` to
+`jwa.Audience` (`[]string`), and the audience check is now membership, not exact equality.
+
+```go
+// before
+jwt.TargetConfig{Audience: "my-service"}
+
+// after
+jwt.TargetConfig{Audience: jwa.Audience{"my-service"}}
+```
+
+Affected fields: `jwa.Claims.Aud`, `jwa.JWH.Aud`, `jwt.TargetConfig.Audience`. A single audience
+still serializes as a bare string (`"aud":"x"`), so existing tokens are unaffected. **Behaviour
+change:** an empty target audience now opts out of the check (it previously rejected any
+aud-bearing token), matching go-jose / golang-jwt.
+
+## Build one `jwk.Source` per JWK Set, not one per key type
+
+`jwk.Source[K]` is no longer generic. One source now serves a whole (mixed) JWK Set, and each
+signer/verifier decodes the key type it needs — so you no longer keep a typed source per algorithm
+family plus a switch on `alg`.
+
+```go
+// before — one typed source + verifier per family, then a manual switch on the token's alg
+rsa := jwk.NewRSAPublicSource(cfg, jwk.RS256)
+ec := jwk.NewECDSAPublicSource(cfg, jwk.ES256)
+
+// after — one source; one verifier per algorithm you accept; the Recipient routes by alg
+source := jwk.NewSource(cfg)
+r := jwt.NewRecipient(jwt.RecipientConfig{Plugins: []jwt.RecipientPlugin{
+	jws.NewSourcedRSAVerifier(source, jws.RS256),
+	jws.NewSourcedECDSAVerifier(source, jws.ES256),
+}})
+```
+
+Removed: `jwk.NewGenericSource`, `jwk.KeyParser`, and the ten typed constructors
+`New{HMAC,AES,RSAPublic,RSAPrivate,ECDSAPublic,ECDSAPrivate,ED25519Public,ED25519Private,ECDHPublic,ECDHPrivate}Source`.
+`jwp.EmbedKey` and `jwp.EmbedKeyConfig` are no longer generic.
+
+This is exactly what an algorithm rotation needs: keep a verifier for the old and the new
+algorithm while both keys live in the set, and one endpoint verifies either — an algorithm with no
+configured verifier is rejected, so the token header only routes among the verifiers you pinned.
+
+## Use the RSA constructors for RSA-PSS
+
+`jws.RSAPSSPreset` and its constructor family are gone; the `PS*` presets are now `RSAPreset`
+values, and the RSA constructors handle both PKCS1v15 (`RS*`) and PSS (`PS*`).
+
+```go
+// before
+s := jws.NewRSAPSSSigner(key, jws.PS256)
+v := jws.NewRSAPSSVerifier(pub, jws.PS256)
+
+// after
+s := jws.NewRSASigner(key, jws.PS256)
+v := jws.NewRSAVerifier(pub, jws.PS256)
+```
+
+Removed: `jws.RSAPSSPreset`, `jws.RSAPSSSigner`, `jws.RSAPSSVerifier`, `jws.SourcedRSAPSSSigner`,
+`jws.SourcedRSAPSSVerifier`, and their `New*` constructors. The `jws.PS256` / `PS384` / `PS512`
+preset names are unchanged.
+
+## Renamed symbols
+
+Only the symbols below changed name; behaviour is identical, and the constructors were already
+named correctly, so most call sites need no edit.
+
+| before | after |
+| --- | --- |
+| `jws.SourceHMACSigner` | `jws.SourcedHMACSigner` |
+| `jws.SourceHMACVerifier` | `jws.SourcedHMACVerifier` |
+| `jwek.PBES2KeyEncKWConfig` | `jwek.PBES2KeyEncKWManager` |
+| `jwek.AESKWPreset` · `AESGCMKWPreset` · `ECDHKeyAgrKWPreset` | `jwek.KeyWrapPreset` |
+
+The `jwek.KeyWrapPreset` instances (`A128KW`, `A128GCMKW`, `ECDHESA128KW`, …) keep their names and
+values — only the type unified.
+
+## Notes
+
+- **Unchanged:** the compact token format, every algorithm's behaviour, and the Ed25519
+  constructors (still `NewED25519Signer(key)` — EdDSA has no parameters). The `v1.3.0` security
+  hardening (parser-DoS caps, RSA/HMAC key-size floors, strict `crit` handling, `jwk.Source`
+  negative caching, protected-header AAD binding) carries into `v2` unchanged.
+- JSON serialization (RFC 7515/7516 §7.2) remains out of scope; compact serialization is fully
+  IANA-compliant, and no consumer needs multi-signature or multi-recipient tokens.

--- a/docs/migrations/v2.0.0.md
+++ b/docs/migrations/v2.0.0.md
@@ -26,8 +26,9 @@ import "github.com/a-novel-kit/jwt/v2/jws"
 
 ```bash
 go get github.com/a-novel-kit/jwt/v2@v2.0.0
-# rewrite the imports across your module (run once):
-find . -name '*.go' -exec sed -i 's|github.com/a-novel-kit/jwt|github.com/a-novel-kit/jwt/v2|g' {} +
+# rewrite the imports across your module (run once). -i.bak is portable across GNU and BSD/macOS sed:
+find . -name '*.go' -exec sed -i.bak 's|github.com/a-novel-kit/jwt|github.com/a-novel-kit/jwt/v2|g' {} +
+find . -name '*.go.bak' -delete
 go mod tidy
 ```
 


### PR DESCRIPTION
## Summary

The migration guide for the upcoming `v2.0.0`, so the released tag ships with its own guide.

- `docs/migrations/v2.0.0.md` — the guide, following the `prepare-release` convention (immutable, one file per version; before/after per breaking change; leads with "Do I need to act?").
- `docs/migrations/README.md` — the newest-first index.
- `README.md` — a one-line pointer to the index (discoverability without piling files at the root).

Covers the six breaking changes: the `/v2` import path, `InsecureVerifier` → `Recipient.DecodeUnverified`, `aud` as `jwa.Audience`, the algorithm-agnostic `jwk.Source`, RSA-PSS via the RSA constructors, and the renamed symbols (`SourceHMAC*`, `PBES2KeyEncKWConfig`, the `KeyWrapPreset` merge).

## Test plan

- [x] Docs only — no code change. Links resolve within the repo.