### PR TITLE
fix(jwk): encode EC coordinates at the curve's full width

### DIFF
--- a/jwk/serializers/ecdsa.go
+++ b/jwk/serializers/ecdsa.go
@@ -142,6 +142,24 @@ func DecodeEC(src *ECPayload) (*ecdsa.PrivateKey, *ecdsa.PublicKey, error) {
 	return keyPriv, keyPub, nil
 }
 
+// encodeCoordinate renders an affine coordinate at the curve's full octet length.
+//
+// RFC 7518 requires x and y to be "the full size of a coordinate for the curve"
+// (https://datatracker.ietf.org/doc/html/rfc7518#section-6.2.1.2), but [big.Int.Bytes] returns the
+// minimal encoding and drops leading zero bytes — which roughly one coordinate in 256 has. A short
+// value is rejected outright by spec-compliant consumers (WebCrypto importKey, jose), while
+// [DecodeEC] reconstructs through [big.Int.SetBytes] and accepts any length, so the defect never
+// surfaces from Go: the package round-trips its own malformed output perfectly.
+//
+// FillBytes panics on a value too large for the buffer; callers pass coordinates read off a parsed
+// key, which are on the curve and therefore fit by construction.
+func encodeCoordinate(curve elliptic.Curve, coordinate *big.Int) string {
+	buf := make([]byte, (curve.Params().BitSize+7)/8)
+	coordinate.FillBytes(buf)
+
+	return base64.RawURLEncoding.EncodeToString(buf)
+}
+
 // EncodeEC builds the ECPayload representation of an ECDSA public or private key.
 func EncodeEC[Key *ecdsa.PublicKey | *ecdsa.PrivateKey](key Key) (*ECPayload, error) {
 	payload := new(ECPayload)
@@ -154,8 +172,8 @@ func EncodeEC[Key *ecdsa.PublicKey | *ecdsa.PrivateKey](key Key) (*ECPayload, er
 		}
 
 		payload.Crv = crv.Params().Name
-		payload.X = base64.RawURLEncoding.EncodeToString(x.Bytes())
-		payload.Y = base64.RawURLEncoding.EncodeToString(y.Bytes())
+		payload.X = encodeCoordinate(crv, x)
+		payload.Y = encodeCoordinate(crv, y)
 
 		return payload, nil
 	}
@@ -176,8 +194,9 @@ func EncodeEC[Key *ecdsa.PublicKey | *ecdsa.PrivateKey](key Key) (*ECPayload, er
 	}
 
 	payload.Crv = crv.Params().Name
-	payload.X = base64.RawURLEncoding.EncodeToString(x.Bytes())
-	payload.Y = base64.RawURLEncoding.EncodeToString(y.Bytes())
+	payload.X = encodeCoordinate(crv, x)
+	payload.Y = encodeCoordinate(crv, y)
+	// privKey.Bytes is already fixed-length per SEC 1 §2.3.7, which is what RFC 7518 §6.2.2.1 wants.
 	payload.D = base64.RawURLEncoding.EncodeToString(privKeyBytes)
 
 	return payload, nil

--- a/jwk/serializers/ecdsa_test.go
+++ b/jwk/serializers/ecdsa_test.go
@@ -4,6 +4,8 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -44,4 +46,64 @@ func TestEC(t *testing.T) {
 		require.Nil(t, decodedPrivateKey)
 		require.True(t, publicKey.Equal(decodedPublicKey))
 	})
+}
+
+// TestECCoordinateWidth pins the RFC 7518 requirement that x and y are encoded at the curve's full
+// coordinate size rather than big.Int's minimal encoding.
+//
+// The fixture is a P-256 key whose x coordinate happens to be below 2^248, so its minimal encoding
+// is 31 bytes instead of 32. Roughly one coordinate in 256 is like this, which is why a randomly
+// generated key — as the round-trip tests above use — almost never exercises the case, and why the
+// round trip could not catch it anyway: DecodeEC reads through big.Int.SetBytes, which accepts any
+// length. Only a consumer in another runtime rejects the short value.
+func TestECCoordinateWidth(t *testing.T) {
+	t.Parallel()
+
+	const (
+		p256ByteLen  = 32
+		shortXKeyHex = "d0b0ae4750701a80ac4b024ce8d70fa3eec161900a1e8b636a88190a5f3102e9"
+	)
+
+	rawKey, err := hex.DecodeString(shortXKeyHex)
+	require.NoError(t, err)
+
+	privateKey, err := ecdsa.ParseRawPrivateKey(elliptic.P256(), rawKey)
+	require.NoError(t, err)
+
+	// Guard the fixture itself: if this ever stops holding, the test below silently stops testing
+	// anything and must be re-seeded with another short-coordinate key. Read through the
+	// uncompressed point (0x04 || X || Y, fixed width) rather than the deprecated PublicKey.X — a
+	// leading zero byte there is exactly what makes big.Int's minimal encoding come out short.
+	rawPoint, err := privateKey.PublicKey.Bytes()
+	require.NoError(t, err)
+	require.Zero(t, rawPoint[1], "fixture no longer has a short x coordinate")
+
+	for _, testCase := range []struct {
+		name    string
+		payload func() (*serializers.ECPayload, error)
+	}{
+		{
+			name:    "PrivateKey",
+			payload: func() (*serializers.ECPayload, error) { return serializers.EncodeEC(privateKey) },
+		},
+		{
+			name:    "PublicKey",
+			payload: func() (*serializers.ECPayload, error) { return serializers.EncodeEC(&privateKey.PublicKey) },
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			payload, err := testCase.payload()
+			require.NoError(t, err)
+
+			x, err := base64.RawURLEncoding.DecodeString(payload.X)
+			require.NoError(t, err)
+			require.Len(t, x, p256ByteLen, "x must be padded to the curve's coordinate size")
+
+			y, err := base64.RawURLEncoding.DecodeString(payload.Y)
+			require.NoError(t, err)
+			require.Len(t, y, p256ByteLen, "y must be padded to the curve's coordinate size")
+		})
+	}
 }


### PR DESCRIPTION
## Summary

- `EncodeEC` rendered `x` and `y` via `big.Int.Bytes()`, the *minimal* encoding. RFC 7518 §6.2.1.2
  requires the full coordinate size for the curve. About one coordinate in 256 has a leading zero
  byte and comes out a byte short.
- The correct primitive was already in this file — `pointFromAffine` uses `FillBytes` for the
  uncompressed-point path. Only the JWK path used `Bytes`.

**This is reachable in production.** `service-json-keys` registers ES256/ES384/ES512 generators, so
its published JWKS carries these keys. A short coordinate is rejected outright by
`crypto.subtle.importKey` and `jose.importJWK`, so an ordinary key rotation has roughly a 0.8 % chance
of publishing a key set no browser can consume.

`d` is untouched: `PrivateKey.Bytes` is already fixed-length per SEC 1 §2.3.7, which is what
RFC 7518 §6.2.2.1 asks for.

## Why this was invisible

`DecodeEC` reconstructs through `big.Int.SetBytes`, which is length-agnostic, so this package
round-trips its own malformed output perfectly and every Go test passes. The failure only appears in
another language runtime, once in ~128 rotations, and reads as "the frontend can't validate tokens
today" with no server-side signal.

The pre-existing `TestEC` round-trip still passes against the broken encoder — I checked. That is the
point: it asserts `privateKey.Equal(decoded)`, which holds whether or not the coordinate is padded.

## Test plan

- [x] `TestECCoordinateWidth` fails against the previous encoder on both the private and public paths
      (31 bytes where 32 is required), and passes after
- [x] Deterministic, not probabilistic — seeded with a fixed short-coordinate key rather than relying
      on a random one landing in the 1-in-256 case
- [x] The fixture carries its own guard, so a re-seed that loses the short coordinate fails loudly
      instead of silently testing nothing
- [x] `a-novel test --type=go -y` passes
- [x] `golangci-lint v2.12.2` reports 0 issues
- [ ] CI green

## Note

Consumers of an already-published short-coordinate key are unaffected by this change — the fix only
alters newly encoded output. Existing malformed keys drain with their TTL; worth deciding separately
whether to force a rotation.

Closes #479