### PR TITLE
feat(jwk): let an unknown key id force a bounded refresh

### DIFF
--- a/jwk/source.go
+++ b/jwk/source.go
@@ -22,6 +22,10 @@ type KeysFetcher func(ctx context.Context) ([]*jwa.JWK, error)
 // RetryInterval unset, so a broken upstream is not called on every request.
 const DefaultRetryInterval = 30 * time.Second
 
+// DefaultUnknownKeyIDInterval bounds how often an unknown key id may force a fetch when
+// RefreshOnUnknownKeyID is set and UnknownKeyIDInterval is not.
+const DefaultUnknownKeyIDInterval = 10 * time.Second
+
 // SourceConfig configures a [Source].
 type SourceConfig struct {
 	// CacheDuration is how long fetched keys are held before the next fetch.
@@ -33,6 +37,30 @@ type SourceConfig struct {
 	// RetryInterval bounds how often a failing Fetch is retried (negative caching), so a broken
 	// upstream is not hit on every request. Non-positive selects DefaultRetryInterval.
 	RetryInterval time.Duration
+	// RefreshOnUnknownKeyID lets a key id absent from the cache force a fetch, instead of reporting
+	// ErrKeyNotFound against a set that may simply be stale.
+	//
+	// Without it a verifier cannot recognise a key the issuer has rotated to until CacheDuration
+	// elapses on its own schedule; every token signed with the new key is rejected until then, and
+	// the symptom — a wall of 401s that a restart cures — is a reliably misdiagnosed failure.
+	//
+	// Off by default because the trigger is attacker-controlled: whoever can present a token chooses
+	// the key id. UnknownKeyIDInterval is what makes it safe to turn on.
+	RefreshOnUnknownKeyID bool
+	// UnknownKeyIDInterval is the minimum age the cache must have before an unknown key id may force
+	// a fetch. Non-positive selects DefaultUnknownKeyIDInterval. Ignored unless
+	// RefreshOnUnknownKeyID is set.
+	//
+	// This is the whole rate limit, and it holds regardless of input: a forced fetch resets the
+	// cache age, so every subsequent unknown id within the interval finds the cache too young and
+	// fetches nothing. A flood of distinct forged key ids therefore costs at most one upstream call
+	// per interval — the same as a single one. Tracking which ids were absent would bound nothing
+	// further and would grow with attacker input.
+	//
+	// The cost of the bound is latency: a genuinely new key id arriving just after a forced fetch
+	// waits up to one interval. That is a different order of magnitude from CacheDuration, which is
+	// the window this exists to close.
+	UnknownKeyIDInterval time.Duration
 }
 
 // A Source fetches and caches the raw JSON Web Keys used to sign or verify tokens, looked up by ID.
@@ -85,32 +113,94 @@ func (source *Source) List(ctx context.Context) ([]*jwa.JWK, error) {
 
 // Get returns the key with the given ID. An empty kid returns the first (highest-priority) key. It
 // returns ErrKeyNotFound when the source is empty or no key matches.
+//
+// With RefreshOnUnknownKeyID set, a named kid absent from the cache forces one bounded fetch before
+// the miss is reported, so a key the issuer has just rotated to is found without waiting out
+// CacheDuration. See UnknownKeyIDInterval for the bound.
 func (source *Source) Get(ctx context.Context, kid string) (*jwa.JWK, error) {
 	err := source.refresh(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("(Source.Get) refresh keys: %w", err)
 	}
 
-	// Search the cache in place under the read lock. Get returns a single key, so — unlike List — it
-	// needs no defensive slice copy, which keeps it cheap on the signing and key-embedding hot paths.
-	source.mu.RLock()
-	defer source.mu.RUnlock()
+	key, found := source.lookup(kid)
+	if found {
+		return key, nil
+	}
 
-	if len(source.cached) == 0 {
+	// An empty kid asks for whichever key ranks first, so a miss means the set is empty rather than
+	// missing a particular key — re-fetching is the caller's business, not a stale-id recovery.
+	if kid == "" || !source.config.RefreshOnUnknownKeyID {
 		return nil, fmt.Errorf("(Source.Get) %w", ErrKeyNotFound)
 	}
 
-	if kid == "" {
-		return source.cached[0], nil
+	refreshed, err := source.refreshForUnknownKeyID(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("(Source.Get) refresh keys: %w", err)
 	}
 
-	for _, key := range source.cached {
-		if key.KID == kid {
+	if refreshed {
+		key, found = source.lookup(kid)
+		if found {
 			return key, nil
 		}
 	}
 
 	return nil, fmt.Errorf("(Source.Get) %w", ErrKeyNotFound)
+}
+
+// lookup resolves kid against the cache under the read lock, reporting whether it matched. An empty
+// kid resolves to the first (highest-priority) key.
+//
+// It returns the cached pointer rather than a copy: Get yields a single key, so — unlike List — it
+// needs no defensive slice copy, which keeps it cheap on the signing and key-embedding hot paths.
+func (source *Source) lookup(kid string) (*jwa.JWK, bool) {
+	source.mu.RLock()
+	defer source.mu.RUnlock()
+
+	if len(source.cached) == 0 {
+		return nil, false
+	}
+
+	if kid == "" {
+		return source.cached[0], true
+	}
+
+	for _, key := range source.cached {
+		if key.KID == kid {
+			return key, true
+		}
+	}
+
+	return nil, false
+}
+
+// refreshForUnknownKeyID fetches when the cache is at least UnknownKeyIDInterval old, reporting
+// whether it did.
+//
+// The age check is the rate limit. Because a fetch resets the cache age, concurrent or successive
+// unknown ids collapse into at most one upstream call per interval however many distinct ids arrive.
+func (source *Source) refreshForUnknownKeyID(ctx context.Context) (bool, error) {
+	interval := source.config.UnknownKeyIDInterval
+	if interval <= 0 {
+		interval = DefaultUnknownKeyIDInterval
+	}
+
+	source.mu.Lock()
+	defer source.mu.Unlock()
+
+	// Re-checked under the write lock: another goroutine may have fetched while we queued for it,
+	// which is what collapses a burst of unknown ids into a single call.
+	if time.Since(source.lastCached) < interval {
+		return false, nil
+	}
+
+	err := source.fetchLocked(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
 }
 
 // fresh reports whether the cache is populated and still within CacheDuration, under a read lock so
@@ -135,6 +225,14 @@ func (source *Source) refresh(ctx context.Context) error {
 		return nil
 	}
 
+	return source.fetchLocked(ctx)
+}
+
+// fetchLocked replaces the cache from Fetch. The caller must hold the write lock.
+//
+// Both refresh paths go through it so the failure backoff applies whichever one reached it: an
+// unknown key id must not become a way around the negative caching that protects a broken upstream.
+func (source *Source) fetchLocked(ctx context.Context) error {
 	// Negative caching: after a failure, don't call Fetch again until RetryInterval has elapsed, so
 	// a broken upstream isn't hit on every request (a thundering-herd / amplification DoS).
 	retry := source.config.RetryInterval
@@ -150,7 +248,7 @@ func (source *Source) refresh(ctx context.Context) error {
 
 	keys, err := source.config.Fetch(ctx)
 	if err != nil {
-		source.lastErr = fmt.Errorf("(Source.refresh) fetch keys: %w", err)
+		source.lastErr = fmt.Errorf("(Source.fetch) fetch keys: %w", err)
 		source.lastFailure = time.Now()
 
 		return source.lastErr

--- a/jwk/source_test.go
+++ b/jwk/source_test.go
@@ -3,6 +3,9 @@ package jwk_test
 import (
 	"context"
 	"errors"
+	"strconv"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -248,4 +251,179 @@ func TestSourceCaches(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, 1, fetchCount)
+}
+
+// Tests for RefreshOnUnknownKeyID: a key id absent from the cache forcing a bounded fetch, so a
+// verifier finds a key the issuer has just rotated to instead of waiting out CacheDuration.
+
+func TestSourceGetUnknownKeyIDDisabled(t *testing.T) {
+	t.Parallel()
+
+	var fetches atomic.Int64
+
+	source := jwk.NewSource(jwk.SourceConfig{
+		CacheDuration: time.Hour,
+		Fetch: func(_ context.Context) ([]*jwa.JWK, error) {
+			fetches.Add(1)
+
+			return []*jwa.JWK{newBullshitKey[string](t, "kid-1").JWK}, nil
+		},
+	})
+
+	_, err := source.Get(t.Context(), "kid-1")
+	require.NoError(t, err)
+
+	// The default must be untouched: an unknown id reports the miss against the cached set without
+	// going upstream, however old that set is.
+	_, err = source.Get(t.Context(), "rotated-kid")
+	require.ErrorIs(t, err, jwk.ErrKeyNotFound)
+	require.EqualValues(t, 1, fetches.Load())
+}
+
+func TestSourceGetUnknownKeyIDRefreshes(t *testing.T) {
+	t.Parallel()
+
+	var (
+		fetches atomic.Int64
+		rotated atomic.Bool
+	)
+
+	source := jwk.NewSource(jwk.SourceConfig{
+		CacheDuration: time.Hour,
+		// Long enough that the cache is nowhere near expiry, so any fetch after the first can only
+		// have come from the unknown-key-id path.
+		RefreshOnUnknownKeyID: true,
+		UnknownKeyIDInterval:  time.Nanosecond,
+		Fetch: func(_ context.Context) ([]*jwa.JWK, error) {
+			fetches.Add(1)
+
+			if rotated.Load() {
+				return []*jwa.JWK{newBullshitKey[string](t, "kid-2").JWK}, nil
+			}
+
+			return []*jwa.JWK{newBullshitKey[string](t, "kid-1").JWK}, nil
+		},
+	})
+
+	_, err := source.Get(t.Context(), "kid-1")
+	require.NoError(t, err)
+	require.EqualValues(t, 1, fetches.Load())
+
+	// The issuer rotates. CacheDuration has not elapsed, so without this feature the new key stays
+	// invisible for an hour.
+	rotated.Store(true)
+
+	key, err := source.Get(t.Context(), "kid-2")
+	require.NoError(t, err)
+	require.Equal(t, "kid-2", key.KID)
+	require.EqualValues(t, 2, fetches.Load())
+}
+
+func TestSourceGetUnknownKeyIDRateLimited(t *testing.T) {
+	t.Parallel()
+
+	var fetches atomic.Int64
+
+	source := jwk.NewSource(jwk.SourceConfig{
+		CacheDuration:         time.Hour,
+		RefreshOnUnknownKeyID: true,
+		UnknownKeyIDInterval:  time.Hour,
+		Fetch: func(_ context.Context) ([]*jwa.JWK, error) {
+			fetches.Add(1)
+
+			return []*jwa.JWK{newBullshitKey[string](t, "kid-1").JWK}, nil
+		},
+	})
+
+	_, err := source.Get(t.Context(), "kid-1")
+	require.NoError(t, err)
+	require.EqualValues(t, 1, fetches.Load())
+
+	// The trigger is attacker-controlled: whoever presents a token picks the key id. A flood of
+	// distinct forged ids must not amplify into a flood of upstream calls.
+	//
+	// Nothing at all goes upstream here, because the bound is the cache's age rather than a count:
+	// the set was just fetched, so no id is old enough to justify re-fetching. The amplification
+	// factor is zero for as long as the interval holds, and one fetch per interval after that —
+	// independent of how many distinct ids arrive.
+	for i := range 500 {
+		_, err = source.Get(t.Context(), "forged-"+strconv.Itoa(i))
+		require.ErrorIs(t, err, jwk.ErrKeyNotFound)
+	}
+
+	require.EqualValues(t, 1, fetches.Load(), "500 distinct unknown key ids must cost no fetch")
+}
+
+func TestSourceGetUnknownKeyIDConcurrent(t *testing.T) {
+	t.Parallel()
+
+	var fetches atomic.Int64
+
+	source := jwk.NewSource(jwk.SourceConfig{
+		CacheDuration:         time.Hour,
+		RefreshOnUnknownKeyID: true,
+		UnknownKeyIDInterval:  time.Hour,
+		Fetch: func(_ context.Context) ([]*jwa.JWK, error) {
+			fetches.Add(1)
+
+			return []*jwa.JWK{newBullshitKey[string](t, "kid-1").JWK}, nil
+		},
+	})
+
+	_, err := source.Get(t.Context(), "kid-1")
+	require.NoError(t, err)
+
+	// Same bound under contention: the age is re-checked under the write lock, so goroutines that
+	// queue behind one another find the cache young rather than each fetching in turn.
+	var wg sync.WaitGroup
+
+	for i := range 50 {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			_, _ = source.Get(t.Context(), "forged-"+strconv.Itoa(i))
+		}()
+	}
+
+	wg.Wait()
+
+	require.EqualValues(t, 1, fetches.Load())
+}
+
+func TestSourceGetUnknownKeyIDHonoursBackoff(t *testing.T) {
+	t.Parallel()
+
+	var fetches atomic.Int64
+
+	errUpstream := errors.New("upstream down")
+
+	source := jwk.NewSource(jwk.SourceConfig{
+		CacheDuration:         time.Hour,
+		RetryInterval:         time.Hour,
+		RefreshOnUnknownKeyID: true,
+		UnknownKeyIDInterval:  time.Nanosecond,
+		Fetch: func(_ context.Context) ([]*jwa.JWK, error) {
+			if fetches.Add(1) == 1 {
+				return []*jwa.JWK{newBullshitKey[string](t, "kid-1").JWK}, nil
+			}
+
+			return nil, errUpstream
+		},
+	})
+
+	_, err := source.Get(t.Context(), "kid-1")
+	require.NoError(t, err)
+
+	// The first unknown id reaches a broken upstream and records the failure.
+	_, err = source.Get(t.Context(), "forged-1")
+	require.ErrorIs(t, err, errUpstream)
+	require.EqualValues(t, 2, fetches.Load())
+
+	// An unknown key id must not be a way around the retry backoff — otherwise the negative caching
+	// that protects a broken upstream is bypassed by the one input an attacker controls.
+	_, err = source.Get(t.Context(), "forged-2")
+	require.ErrorIs(t, err, errUpstream)
+	require.EqualValues(t, 2, fetches.Load(), "the backoff must hold on the unknown-key-id path")
 }

--- a/jws/rotation_test.go
+++ b/jws/rotation_test.go
@@ -2,7 +2,10 @@ package jws_test
 
 import (
 	"context"
+	"crypto/rsa"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -110,4 +113,105 @@ func TestSourcedVerifierSurfacesMalformedKey(t *testing.T) {
 	err = recipient.Consume(t.Context(), token, &got)
 	require.Error(t, err)
 	require.NotErrorIs(t, err, jws.ErrInvalidSignature)
+}
+
+// TestSourcedRotationUnknownKeyID is the acceptance test for RefreshOnUnknownKeyID, and it exercises
+// the path the defect actually lived on.
+//
+// verifyFromSource reads through Source.List, not Source.Get, so a source that only re-fetched on a
+// Get miss would have changed nothing here: the verifier would still walk a stale set, skip every key
+// whose id does not match the header, and report an invalid signature. That is the failure this
+// closes — a wall of 401s, after an ordinary key rotation, that a restart cures.
+func TestSourcedRotationUnknownKeyID(t *testing.T) {
+	t.Parallel()
+
+	oldPriv, oldPub, err := jwk.GenerateRSA(jwk.RS256)
+	require.NoError(t, err)
+
+	newPriv, newPub, err := jwk.GenerateRSA(jwk.RS256)
+	require.NoError(t, err)
+
+	claims := map[string]any{"foo": "bar"}
+
+	// The issuer signs with whichever key it currently holds, naming it in the header — which is what
+	// gives the consumer an id to miss on.
+	issue := func(t *testing.T, key *jwk.Key[*rsa.PrivateKey]) string {
+		t.Helper()
+
+		issuerSource := jwk.NewSource(jwk.SourceConfig{
+			Fetch: func(_ context.Context) ([]*jwa.JWK, error) { return []*jwa.JWK{key.JWK}, nil },
+		})
+
+		token, issueErr := jwt.NewProducer(jwt.ProducerConfig{
+			Plugins: []jwt.ProducerPlugin{jws.NewSourcedRSASigner(issuerSource, jws.RS256)},
+		}).Issue(t.Context(), claims, nil)
+		require.NoError(t, issueErr)
+
+		return token
+	}
+
+	oldToken := issue(t, oldPriv)
+	newToken := issue(t, newPriv)
+
+	// A consumer whose cache is an hour long. Rotation is invisible to it until the cache expires,
+	// unless an unknown key id can force the issue.
+	newConsumer := func(t *testing.T, rotated *atomic.Bool, refreshOnUnknown bool) *jwt.Recipient {
+		t.Helper()
+
+		source := jwk.NewSource(jwk.SourceConfig{
+			CacheDuration:         time.Hour,
+			RefreshOnUnknownKeyID: refreshOnUnknown,
+			UnknownKeyIDInterval:  time.Nanosecond,
+			Fetch: func(_ context.Context) ([]*jwa.JWK, error) {
+				if rotated.Load() {
+					return []*jwa.JWK{newPub.JWK}, nil
+				}
+
+				return []*jwa.JWK{oldPub.JWK}, nil
+			},
+		})
+
+		return jwt.NewRecipient(jwt.RecipientConfig{
+			Plugins: []jwt.RecipientPlugin{jws.NewSourcedRSAVerifier(source, jws.RS256)},
+		})
+	}
+
+	t.Run("Disabled", func(t *testing.T) {
+		t.Parallel()
+
+		var rotated atomic.Bool
+
+		recipient := newConsumer(t, &rotated, false)
+
+		var got map[string]any
+
+		// Warm the cache on the pre-rotation key set.
+		require.NoError(t, recipient.Consume(t.Context(), oldToken, &got))
+
+		rotated.Store(true)
+
+		// The default is unchanged: the rotated key stays unverifiable until CacheDuration elapses.
+		require.Error(t, recipient.Consume(t.Context(), newToken, &got))
+	})
+
+	t.Run("Enabled", func(t *testing.T) {
+		t.Parallel()
+
+		var rotated atomic.Bool
+
+		recipient := newConsumer(t, &rotated, true)
+
+		var got map[string]any
+
+		require.NoError(t, recipient.Consume(t.Context(), oldToken, &got))
+
+		rotated.Store(true)
+
+		got = nil
+
+		// The header names a key id the cached set does not hold, so the source is asked for it
+		// directly and re-fetches — inside the same request, without waiting out the cache.
+		require.NoError(t, recipient.Consume(t.Context(), newToken, &got))
+		require.Equal(t, claims, got)
+	})
 }

--- a/jws/sourced.go
+++ b/jws/sourced.go
@@ -27,24 +27,16 @@ func verifyFromSource[K any](
 	decode keyDecoder[K],
 	newVerifier func(key K) jwt.RecipientPlugin,
 ) ([]byte, error) {
-	keys, err := source.List(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("(verifyFromSource) list keys: %w", err)
-	}
-
-	for _, candidate := range keys {
-		// A token that names a KID can only match that key; skip the rest.
-		if header.KID != "" && candidate.KID != header.KID {
-			continue
-		}
-
+	// try reports whether candidate verified the token. A nil payload with a nil error means the
+	// candidate was not this verifier's to use, or did not verify — either way, keep looking.
+	try := func(candidate *jwa.JWK) ([]byte, error) {
 		key, decodeErr := decode(candidate)
 		if decodeErr != nil {
 			// A key of another algorithm family is not this verifier's to use — skip it. But a key of
 			// the right family that fails to decode (malformed material) is a real error to surface,
 			// not one to mask as an invalid signature.
 			if errors.Is(decodeErr, jwk.ErrJWKMismatch) {
-				continue
+				return nil, nil
 			}
 
 			return nil, fmt.Errorf("(verifyFromSource) decode key: %w", decodeErr)
@@ -58,6 +50,62 @@ func verifyFromSource[K any](
 		if !errors.Is(verifyErr, ErrInvalidSignature) {
 			return nil, fmt.Errorf("(verifyFromSource) %w", verifyErr)
 		}
+
+		return nil, nil
+	}
+
+	keys, err := source.List(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("(verifyFromSource) list keys: %w", err)
+	}
+
+	named := false
+
+	for _, candidate := range keys {
+		// A token that names a KID can only match that key; skip the rest.
+		if header.KID != "" && candidate.KID != header.KID {
+			continue
+		}
+
+		named = true
+
+		payload, tryErr := try(candidate)
+		if tryErr != nil {
+			return nil, tryErr
+		}
+
+		if payload != nil {
+			return payload, nil
+		}
+	}
+
+	// Every candidate the cached set offered has been tried.
+	if header.KID == "" || named {
+		return nil, fmt.Errorf("(verifyFromSource) %w", ErrInvalidSignature)
+	}
+
+	// The token names a key id the cached set does not hold. That is what a rotation looks like from
+	// here — the issuer has moved on and this set predates it — so ask the source for the id directly
+	// rather than concluding the signature is invalid. The source decides whether to go upstream;
+	// with RefreshOnUnknownKeyID unset this is a cache scan that changes nothing.
+	candidate, err := source.Get(ctx, header.KID)
+	if err != nil {
+		// Still unknown after the source has had its say: the signature is unverifiable, which is
+		// what the caller needs to hear.
+		if errors.Is(err, jwk.ErrKeyNotFound) {
+			return nil, fmt.Errorf("(verifyFromSource) %w", ErrInvalidSignature)
+		}
+
+		return nil, fmt.Errorf("(verifyFromSource) get key: %w", err)
+	}
+
+	payload, err := try(candidate)
+	if err != nil {
+		return nil, err
+	}
+
+	if payload != nil {
+		return payload, nil
 	}
 
 	return nil, fmt.Errorf("(verifyFromSource) %w", ErrInvalidSignature)


### PR DESCRIPTION
## Summary

A verifier holding a cached key set cannot recognise a key the issuer has rotated to until
`CacheDuration` elapses on its own schedule. Every token signed with the new key is rejected until
then — a wall of 401s that a restart cures, which is one of the most reliably misdiagnosed failures in
distributed authentication.

`RefreshOnUnknownKeyID` lets a named key id absent from the cache force one bounded fetch. **Opt-in**,
so nothing changes for existing callers.

## The gap the issue missed — and why the fix is two-sided

The issue proposed adding the refresh to `Source.Get`. That alone would have fixed **nothing**:
`verifyFromSource` reads through `Source.List`, not `Get`. The verifier would still walk a stale set,
`continue` past every key whose id does not match the header, and fall through to
`ErrInvalidSignature` — never asking the source about the id it could not find.

So the verifier now asks for a missing named id directly. That is the half the defect actually lived
on, and the acceptance test **fails with the source-side change fully present and the verifier-side
one removed** — which is how I found it.

The verifier change is safe with the feature off: `Get` on a miss is a cache scan returning
`ErrKeyNotFound`, mapped to the same `ErrInvalidSignature` the loop already produced.

## Rate limiting

The trigger is attacker-controlled — whoever presents a token picks the key id — so the bound matters
more than the feature.

**The bound is the cache's age, not a counter or a set of seen ids.** A forced fetch resets the age,
so every unknown id arriving within `UnknownKeyIDInterval` finds the cache too young and fetches
nothing. A flood of 500 distinct forged ids therefore costs the same as one: nothing, until the
interval lapses, then at most one call.

This deviates from the issue, which proposed a per-key-id negative cache alongside an interval. I
dropped it: it bounds nothing the age check does not already bound, and it is a map that **grows with
attacker input** — a memory-growth vector introduced by the mitigation, which would be an unfortunate
thing to add while closing a silent-failure defect.

Both refresh paths now share `fetchLocked`, so the existing failure backoff applies to whichever
reached it. An unknown key id must not become a way around the negative caching that protects a broken
upstream — there is a test for exactly that.

## Trade-off

A genuinely new key id arriving just after a forced fetch waits up to one interval (default 10s).
That is a different order of magnitude from `CacheDuration` (30 min in our services), which is the
window this exists to close.

## Test plan

- [x] `TestSourcedRotationUnknownKeyID/Enabled` fails when the verifier-side change is removed, with
      the source-side change still in place — the proof both halves are load-bearing
- [x] `/Disabled` asserts the default is unchanged: the rotated key stays unverifiable
- [x] Rate limit: 500 distinct forged ids sequentially, and 50 concurrently, cost zero fetches
- [x] An unknown key id cannot bypass the retry backoff on a failing upstream
- [x] `a-novel test --type=go -y` passes; `golangci-lint v2.12.2` reports 0 issues
- [ ] CI green

## Release

Additive and opt-in — a **minor** on top of `v2.0.1`. No consumer changes anything unless it opts in;
`service-json-keys`' hardcoded preset means turning it on there is a separate decision.

Closes #476