### PR TITLE
docs: trim and refocus code comments

### DIFF
--- a/crit.go
+++ b/crit.go
@@ -15,8 +15,8 @@ var ErrMissingCritHeader = errors.New("missing crit header value")
 var ErrUnsupportedCritHeader = errors.New("unsupported crit header")
 
 // reservedHeaderParams are the header parameters defined by the JWS/JWE/JWA/JWT specifications. A
-// producer MUST NOT mark any of them critical (RFC 7515 §4.1.11), so a recipient rejects a crit
-// list that names one — otherwise "crit" could be used to smuggle contradictory processing rules.
+// producer must not mark any of them critical (RFC 7515 §4.1.11), so a recipient rejects a crit list
+// that names one; otherwise "crit" could smuggle contradictory processing rules.
 var reservedHeaderParams = map[string]bool{
 	"alg": true, "jku": true, "jwk": true, "kid": true,
 	"x5u": true, "x5c": true, "x5t": true, "x5t#S256": true,
@@ -57,14 +57,14 @@ func CheckCrit(data json.RawMessage, crit []string) error {
 }
 
 // CheckCritUnderstood enforces the recipient's "crit" obligation (RFC 7515 §4.1.11): the token is
-// invalid unless every listed critical extension is understood by the recipient AND present in the
-// header. understood is the set of extension names the recipient is configured to process; any crit
-// entry outside it — or one naming a registered JOSE parameter — is rejected. data is the decoded
-// header (the same JSON object CheckCrit inspects for presence). A present but empty crit list is
-// itself invalid, so callers pass crit only when the member is present.
+// invalid unless every listed critical extension is both understood by the recipient and present in
+// the header. understood is the set of extension names the recipient is configured to process; any
+// crit entry outside it, or one naming a registered JOSE parameter, is rejected. data is the decoded
+// header. A present but empty crit list is itself invalid, so callers pass crit only when the member
+// is present.
 func CheckCritUnderstood(data json.RawMessage, crit, understood []string) error {
-	// A present "crit" list must not be empty (RFC 7515 §4.1.11); the caller invokes this only when
-	// the member is present, so an empty slice here is the forbidden "crit":[] case.
+	// The caller invokes this only when the member is present, so an empty slice is the "crit":[]
+	// form RFC 7515 §4.1.11 forbids.
 	if len(crit) == 0 {
 		return fmt.Errorf("%w: crit list must not be empty", ErrUnsupportedCritHeader)
 	}
@@ -84,6 +84,6 @@ func CheckCritUnderstood(data json.RawMessage, crit, understood []string) error 
 		}
 	}
 
-	// Every understood critical extension must also actually be present in the header.
+	// Every understood critical extension must also be present in the header.
 	return CheckCrit(data, crit)
 }

--- a/jwe/aec_gcm_test.go
+++ b/jwe/aec_gcm_test.go
@@ -339,8 +339,8 @@ func TestAESGCMHeaderBound(t *testing.T) {
 	token, err := producer.Issue(t.Context(), map[string]any{"foo": "bar"}, nil)
 	require.NoError(t, err)
 
-	// The protected header is bound as AAD now. Swapping it for a different (still enc-valid) header
-	// must fail decryption.
+	// The protected header is bound as AAD, so swapping it for a different but still enc-valid header
+	// fails decryption.
 	parts, err := jwt.DecodeToken(token, &jwt.EncryptedTokenDecoder{})
 	require.NoError(t, err)
 
@@ -353,6 +353,6 @@ func TestAESGCMHeaderBound(t *testing.T) {
 
 	var claims map[string]any
 
-	// The tamper fails as an authenticated-decryption error, not an unrelated parse failure.
+	// The tamper surfaces as an authenticated-decryption error.
 	require.ErrorIs(t, recipient.Consume(t.Context(), parts.String(), &claims), jwe.ErrInvalidSecret)
 }

--- a/jwe/aes_cbc.go
+++ b/jwe/aes_cbc.go
@@ -18,7 +18,7 @@ import (
 
 // AESCBCPreset holds the parameters of one AES_CBC_HMAC_SHA2 variant: the enc
 // identifier, the HMAC hash, and the key and tag lengths. Use one of the package
-// presets rather than assembling this by hand.
+// presets.
 type AESCBCPreset struct {
 	Enc       jwa.Enc
 	Hash      crypto.Hash
@@ -107,7 +107,7 @@ func (enc *AESCBCEncryption) Header(ctx context.Context, header *jwa.JWH) (*jwa.
 		return nil, fmt.Errorf("(AESCBCEncryption.Header) set key derivation header: %w", err)
 	}
 
-	// A CEKManager may pin the token to a specific enc; honor that pin rather than override it.
+	// A CEKManager may pin the token to a specific enc; honor that pin.
 	if header.Enc != "" && header.Enc != enc.enc {
 		return nil, fmt.Errorf(
 			"(AESCBCEncryption.Header) %w: cek manager is incompatible with the current encryption algorithm: "+
@@ -173,8 +173,8 @@ func (enc *AESCBCEncryption) Transform(ctx context.Context, header *jwa.JWH, raw
 	al := make([]byte, 8)
 	binary.BigEndian.PutUint64(al, uint64(len(aadBytes)*8))
 
-	// The tag is HMAC over AAD, IV, ciphertext, and AL in that order, truncated to tagLength
-	// octets. The order is fixed by the spec.
+	// The tag is HMAC over AAD, IV, ciphertext, and AL in the order the spec fixes, truncated to
+	// tagLength octets.
 	authenticationTag := hmac.New(enc.hash.New, macKey)
 	authenticationTag.Write(aadBytes)
 	authenticationTag.Write(iv)

--- a/jwe/aes_gcm.go
+++ b/jwe/aes_gcm.go
@@ -13,7 +13,7 @@ import (
 )
 
 // AESGCMPreset holds the parameters of one AES-GCM variant: the enc identifier and
-// the key length. Use one of the package presets rather than assembling this by hand.
+// the key length. Use one of the package presets.
 type AESGCMPreset struct {
 	Enc    jwa.Enc
 	KeyLen int
@@ -77,7 +77,7 @@ func (enc *AESGCMEncryption) Header(ctx context.Context, header *jwa.JWH) (*jwa.
 		return nil, fmt.Errorf("(AESGCMEncryption.Header) set key derivation header: %w", err)
 	}
 
-	// A CEKManager may pin the token to a specific enc; honor that pin rather than override it.
+	// A CEKManager may pin the token to a specific enc; honor that pin.
 	if header.Enc != "" && header.Enc != enc.enc {
 		return nil, fmt.Errorf(
 			"(AESGCMEncryption.Header) %w: cek manager is incompatible with the current encryption algorithm: "+
@@ -272,8 +272,8 @@ func (dec *AESGCMDecryption) Transform(ctx context.Context, header *jwa.JWH, raw
 
 	plainText, err := aesgcm.Open(nil, iv, append(cipherText, tag...), aad(token.Header, dec.additionalData))
 	if err != nil {
-		// An authenticated-decryption failure is the GCM analogue of a bad HMAC tag; surface the
-		// same sentinel the CBC path uses so callers can treat auth failures uniformly.
+		// An authenticated-decryption failure is the GCM analogue of a bad HMAC tag, so it surfaces
+		// the same sentinel as the CBC path.
 		return nil, fmt.Errorf("(AESGCMDecryption.Transform) %w: %w", ErrInvalidSecret, err)
 	}
 

--- a/jwe/internal/concat_kdf.go
+++ b/jwe/internal/concat_kdf.go
@@ -1,7 +1,6 @@
 // Package internal holds the low-level cryptographic primitives that the JWE key-management
 // algorithms compose: key derivation, key wrapping, and padding. They live here so several
-// algorithm implementations can share one vetted implementation of each primitive instead of
-// duplicating it.
+// algorithm implementations share one vetted implementation of each primitive.
 package internal
 
 import (
@@ -29,9 +28,8 @@ func ConcatKDF(
 	h := hash.New()
 	output := make([]byte, 0, keyDataLen)
 
-	// The 32-bit block counter (the buffer's first four bytes) increments each round. Left fixed,
-	// every hash block would be identical and any key longer than one hash output would repeat —
-	// for AES-CBC-HMAC that collapses the MAC and ENC key halves into the same value.
+	// The 32-bit block counter (the buffer's first four bytes) increments each round, so every hash
+	// block differs. For AES-CBC-HMAC the two halves become the MAC and ENC keys.
 	for round := uint32(1); len(output) < keyDataLen; round++ {
 		binary.BigEndian.PutUint32(buffer[:4], round)
 		h.Write(buffer)

--- a/jwe/internal/concat_kdf.go
+++ b/jwe/internal/concat_kdf.go
@@ -17,7 +17,6 @@ func ConcatKDF(
 ) []byte {
 	buffer := make([]byte, 4+len(z)+len(algID)+len(pUInfo)+len(pVInfo)+len(supPubInfo)+len(supPrivInfo))
 
-	// Concatenate all inputs.
 	n := 0
 	n += copy(buffer[n:], []byte{0, 0, 0, 1})
 	n += copy(buffer[n:], z)
@@ -30,9 +29,9 @@ func ConcatKDF(
 	h := hash.New()
 	output := make([]byte, 0, keyDataLen)
 
-	// The 32-bit block counter (the buffer's first four bytes) MUST increment each round. Left
-	// fixed, every hash block would be identical and any key longer than one hash output would
-	// repeat — for AES-CBC-HMAC that collapses the MAC and ENC key halves into the same value.
+	// The 32-bit block counter (the buffer's first four bytes) increments each round. Left fixed,
+	// every hash block would be identical and any key longer than one hash output would repeat —
+	// for AES-CBC-HMAC that collapses the MAC and ENC key halves into the same value.
 	for round := uint32(1); len(output) < keyDataLen; round++ {
 		binary.BigEndian.PutUint32(buffer[:4], round)
 		h.Write(buffer)

--- a/jwe/internal/concat_kdf_test.go
+++ b/jwe/internal/concat_kdf_test.go
@@ -39,9 +39,9 @@ func TestVectorConcatKDF(t *testing.T) {
 func TestConcatKDFMultiBlock(t *testing.T) {
 	t.Parallel()
 
-	// Deriving more than one hash block must advance the round counter, so consecutive blocks
-	// differ. With a fixed counter they would be identical — the bug this guards against, which
-	// would collapse the MAC and ENC key halves of an AES-CBC-HMAC key into the same value.
+	// Deriving more than one hash block advances the round counter, so consecutive blocks differ. A
+	// fixed counter would repeat them, collapsing the MAC and ENC key halves of an AES-CBC-HMAC key
+	// into the same value.
 	out := internal.ConcatKDF(crypto.SHA256, []byte("shared-secret"), 64, nil, nil, nil, nil, nil)
 	require.Len(t, out, 64)
 	require.NotEqual(t, out[:32], out[32:])

--- a/jwe/internal/concat_kdf_test.go
+++ b/jwe/internal/concat_kdf_test.go
@@ -39,9 +39,7 @@ func TestVectorConcatKDF(t *testing.T) {
 func TestConcatKDFMultiBlock(t *testing.T) {
 	t.Parallel()
 
-	// Deriving more than one hash block advances the round counter, so consecutive blocks differ. A
-	// fixed counter would repeat them, collapsing the MAC and ENC key halves of an AES-CBC-HMAC key
-	// into the same value.
+	// The halves become the MAC and ENC keys of an AES-CBC-HMAC key. Both must differ.
 	out := internal.ConcatKDF(crypto.SHA256, []byte("shared-secret"), 64, nil, nil, nil, nil, nil)
 	require.Len(t, out, 64)
 	require.NotEqual(t, out[:32], out[32:])

--- a/jwe/internal/pkcs.go
+++ b/jwe/internal/pkcs.go
@@ -16,8 +16,8 @@ func PKCS7Padding(ciphertext []byte, blockSize int) []byte {
 }
 
 // PKCS7UnPadding strips the PKCS#7 padding that PKCS7Padding added, returning the original
-// plaintext. It validates the padding rather than trusting the last byte: an out-of-range or
-// inconsistent pad length would otherwise slice out of bounds and panic.
+// plaintext. It validates the pad length and every pad byte, so an out-of-range or inconsistent
+// length fails instead of slicing out of bounds.
 func PKCS7UnPadding(plaintText []byte) ([]byte, error) {
 	length := len(plaintText)
 	if length == 0 {

--- a/jwe/internal/pkcs.go
+++ b/jwe/internal/pkcs.go
@@ -16,8 +16,8 @@ func PKCS7Padding(ciphertext []byte, blockSize int) []byte {
 }
 
 // PKCS7UnPadding strips the PKCS#7 padding that PKCS7Padding added, returning the original
-// plaintext. It validates the pad length and every pad byte, so an out-of-range or inconsistent
-// length fails instead of slicing out of bounds.
+// plaintext. It validates the pad length and every pad byte, returning an error for an
+// out-of-range or inconsistent length.
 func PKCS7UnPadding(plaintText []byte) ([]byte, error) {
 	length := len(plaintText)
 	if length == 0 {

--- a/jwe/jwek/aes_key_wrap.go
+++ b/jwe/jwek/aes_key_wrap.go
@@ -13,7 +13,7 @@ import (
 // KeyWrapPreset pairs a JWA algorithm identifier with its wrap-key length. It is shared by the
 // AES-KW, AES-GCM-KW, and ECDH-ES+AES-KW key managers, which carry the same two fields; for ECDH-ES
 // the length is that of the key-wrapping key derived from the shared secret. Use one of the
-// predefined presets rather than building one by hand.
+// predefined presets.
 type KeyWrapPreset struct {
 	Alg    jwa.Alg
 	KeyLen int

--- a/jwe/jwek/assertions.go
+++ b/jwe/jwek/assertions.go
@@ -3,8 +3,7 @@ package jwek
 import "github.com/a-novel-kit/jwt/v2/jwe"
 
 // Compile-time checks that every key manager and decoder satisfies the jwe.CEKManager /
-// jwe.CEKDecoder contract. This is exactly the guard that would have caught DirectKeyManager's
-// signature drift before it shipped.
+// jwe.CEKDecoder contract, so a drifting method signature fails the build.
 var (
 	_ jwe.CEKManager = (*AESGCMKWManager)(nil)
 	_ jwe.CEKManager = (*RSAOAEPKeyEncManager)(nil)

--- a/jwe/jwek/key_derivation_ecdh.go
+++ b/jwe/jwek/key_derivation_ecdh.go
@@ -15,9 +15,8 @@ import (
 )
 
 // ECDHKeyAgrPreset binds a content-encryption algorithm to its derived-key length
-// for ECDH-ES key agreement. Each preset targets one specific encryption and is
-// not interchangeable. Use one of the predefined presets rather than building one
-// by hand.
+// for ECDH-ES key agreement. Use one of the predefined presets, each of which
+// targets one specific encryption.
 type ECDHKeyAgrPreset struct {
 	Enc    jwa.Enc
 	Alg    jwa.Alg
@@ -66,7 +65,7 @@ type ECDHKeyAgrManagerConfig struct {
 }
 
 // ECDHKeyAgrManager implements jwe.CEKManager for ECDH-ES key agreement: it derives
-// the content encryption key from a shared secret instead of wrapping one into the
+// the content encryption key from a shared secret, so nothing is wrapped into the
 // token. See RFC 7518 section 4.6.
 type ECDHKeyAgrManager struct {
 	config ECDHKeyAgrManagerConfig
@@ -80,9 +79,8 @@ type ECDHKeyAgrManager struct {
 // content-encryption algorithm and derived-key length; use one of the
 // ECDHKeyAgrPreset values (for example ECDHESA128CBC).
 //
-// The preset is bound to a specific jwe encryption and is not interchangeable:
-// pick the encryption whose name matches the preset (for example ECDHESA128CBC
-// pairs with jwe.A128CBCHS256).
+// Pick the encryption whose name matches the preset: ECDHESA128CBC pairs with
+// jwe.A128CBCHS256.
 //
 // https://datatracker.ietf.org/doc/html/rfc7518#section-4.6
 func NewECDHKeyAgrManager(config *ECDHKeyAgrManagerConfig, preset ECDHKeyAgrPreset) *ECDHKeyAgrManager {
@@ -159,9 +157,8 @@ type ECDHKeyAgrDecoder struct {
 // used to encrypt the token; use one of the ECDHKeyAgrPreset values (for example
 // ECDHESA128CBC).
 //
-// The preset is bound to a specific jwe encryption and is not interchangeable:
-// pick the encryption whose name matches the preset (for example ECDHESA128CBC
-// pairs with jwe.A128CBCHS256).
+// Pick the encryption whose name matches the preset: ECDHESA128CBC pairs with
+// jwe.A128CBCHS256.
 //
 // https://datatracker.ietf.org/doc/html/rfc7518#section-4.6
 func NewECDHKeyAgrDecoder(config *ECDHKeyAgrDecoderConfig, preset ECDHKeyAgrPreset) *ECDHKeyAgrDecoder {

--- a/jwe/jwek/pbes2_key_enc.go
+++ b/jwe/jwek/pbes2_key_enc.go
@@ -16,8 +16,7 @@ import (
 )
 
 // PBES2KeyEncKWPreset pairs a JWA algorithm identifier with the hash and key size
-// used to derive the wrap key from the password. Use one of the predefined presets
-// rather than building one by hand.
+// used to derive the wrap key from the password. Use one of the predefined presets.
 type PBES2KeyEncKWPreset struct {
 	Alg     jwa.Alg
 	Hash    crypto.Hash
@@ -91,8 +90,8 @@ func (manager *PBES2KeyEncKWManager) SetHeader(_ context.Context, header *jwa.JW
 		return nil, fmt.Errorf("(PBES2KeyEncKWManager.SetHeader) %w: alg field already set", jwt.ErrConflictingHeader)
 	}
 
-	// A fresh salt per token widens the key space so the same password never
-	// derives the same wrap key twice. It travels in the header for the recipient.
+	// A fresh salt per token widens the key space, so one password never derives the
+	// same wrap key twice. It travels in the header for the recipient.
 	salt := make([]byte, manager.config.SaltSize)
 
 	_, err := rand.Read(salt)
@@ -137,7 +136,7 @@ func (manager *PBES2KeyEncKWManager) EncryptCEK(_ context.Context, header *jwa.J
 
 // DefaultMaxPBES2Iterations caps the PBKDF2 iteration count (p2c) a decoder will run when the
 // config leaves MaxIterations unset. p2c is attacker-controlled in the token header, so an
-// unbounded value is a CPU-exhaustion DoS; this matches the 1,000,000 ceiling go-jose uses.
+// unbounded value is a CPU-exhaustion vector.
 const DefaultMaxPBES2Iterations = 1_000_000
 
 // PBES2KeyEncKWDecoderConfig holds the password used to re-derive the wrap key and
@@ -198,8 +197,8 @@ func (decoder *PBES2KeyEncKWDecoder) ComputeCEK(_ context.Context, header *jwa.J
 		)
 	}
 
-	// p2c is attacker-controlled; run PBKDF2 only within a sane bound, or a single small token can
-	// pin a core for billions of iterations.
+	// Bound the attacker-controlled p2c before PBKDF2 runs; a small token could otherwise pin a core
+	// for billions of iterations.
 	if header.P2C <= 0 || header.P2C > decoder.maxIterations {
 		return nil, fmt.Errorf(
 			"(PBES2KeyEncKWDecoder.ComputeCEK) %w: p2c %d out of range (1..%d)",

--- a/jwe/jwek/rsa_oaep_key_enc.go
+++ b/jwe/jwek/rsa_oaep_key_enc.go
@@ -14,7 +14,7 @@ import (
 )
 
 // RSAOAEPKeyEncPreset pairs a JWA algorithm identifier with the hash used by
-// RSAES-OAEP. Use one of the predefined presets rather than building one by hand.
+// RSAES-OAEP. Use one of the predefined presets.
 type RSAOAEPKeyEncPreset struct {
 	Alg  jwa.Alg
 	Hash hash.Hash

--- a/jwk/rsa.go
+++ b/jwk/rsa.go
@@ -15,6 +15,9 @@ import (
 // An RSAPreset describes how to generate or match an RSA JSON Web Key: the algorithm it is bound
 // to, whether the key is used for signatures or key management, the operations allowed on each
 // half of the pair, and the modulus size in bits.
+//
+// A modulus of n bits signs into ⌈n/8⌉ bytes, which is what pairs the 2048-, 3072-, and 4096-bit
+// signature presets with the SHA-256, SHA-384, and SHA-512 variants.
 type RSAPreset struct {
 	Alg           jwa.Alg
 	Use           jwa.Use
@@ -30,39 +33,21 @@ var (
 		Use:           jwa.UseSig,
 		PrivateKeyOps: jwa.KeyOps{jwa.KeyOpSign},
 		PublicKeyOps:  jwa.KeyOps{jwa.KeyOpVerify},
-		// The signature size (in bytes, before re-encoding as text) is the key size (in bit), divided by 8 and rounded up
-		// to the next integer.
-		//
-		// ⌈2048/8⌉=256 bytes.
-		//
-		// https://crypto.stackexchange.com/a/95882
-		KeySize: 2048,
+		KeySize:       2048,
 	}
 	RS384 = RSAPreset{
 		Alg:           jwa.RS384,
 		Use:           jwa.UseSig,
 		PrivateKeyOps: jwa.KeyOps{jwa.KeyOpSign},
 		PublicKeyOps:  jwa.KeyOps{jwa.KeyOpVerify},
-		// The signature size (in bytes, before re-encoding as text) is the key size (in bit), divided by 8 and rounded up
-		// to the next integer.
-		//
-		// ⌈3072/8⌉=384 bytes.
-		//
-		// https://crypto.stackexchange.com/a/95882
-		KeySize: 3072,
+		KeySize:       3072,
 	}
 	RS512 = RSAPreset{
 		Alg:           jwa.RS512,
 		Use:           jwa.UseSig,
 		PrivateKeyOps: jwa.KeyOps{jwa.KeyOpSign},
 		PublicKeyOps:  jwa.KeyOps{jwa.KeyOpVerify},
-		// The signature size (in bytes, before re-encoding as text) is the key size (in bit), divided by 8 and rounded up
-		// to the next integer.
-		//
-		// ⌈4096/8⌉=512 bytes.
-		//
-		// https://crypto.stackexchange.com/a/95882
-		KeySize: 4096,
+		KeySize:       4096,
 	}
 
 	PS256 = RSAPreset{
@@ -70,39 +55,21 @@ var (
 		Use:           jwa.UseSig,
 		PrivateKeyOps: jwa.KeyOps{jwa.KeyOpSign},
 		PublicKeyOps:  jwa.KeyOps{jwa.KeyOpVerify},
-		// The signature size (in bytes, before re-encoding as text) is the key size (in bit), divided by 8 and rounded up
-		// to the next integer.
-		//
-		// ⌈2048/8⌉=256 bytes.
-		//
-		// https://crypto.stackexchange.com/a/95882
-		KeySize: 2048,
+		KeySize:       2048,
 	}
 	PS384 = RSAPreset{
 		Alg:           jwa.PS384,
 		Use:           jwa.UseSig,
 		PrivateKeyOps: jwa.KeyOps{jwa.KeyOpSign},
 		PublicKeyOps:  jwa.KeyOps{jwa.KeyOpVerify},
-		// The signature size (in bytes, before re-encoding as text) is the key size (in bit), divided by 8 and rounded up
-		// to the next integer.
-		//
-		// ⌈3072/8⌉=384 bytes.
-		//
-		// https://crypto.stackexchange.com/a/95882
-		KeySize: 3072,
+		KeySize:       3072,
 	}
 	PS512 = RSAPreset{
 		Alg:           jwa.PS512,
 		Use:           jwa.UseSig,
 		PrivateKeyOps: jwa.KeyOps{jwa.KeyOpSign},
 		PublicKeyOps:  jwa.KeyOps{jwa.KeyOpVerify},
-		// The signature size (in bytes, before re-encoding as text) is the key size (in bit), divided by 8 and rounded up
-		// to the next integer.
-		//
-		// ⌈4096/8⌉=512 bytes.
-		//
-		// https://crypto.stackexchange.com/a/95882
-		KeySize: 4096,
+		KeySize:       4096,
 	}
 )
 

--- a/jwk/serializers/ecdsa.go
+++ b/jwk/serializers/ecdsa.go
@@ -145,11 +145,10 @@ func DecodeEC(src *ECPayload) (*ecdsa.PrivateKey, *ecdsa.PublicKey, error) {
 // encodeCoordinate renders an affine coordinate at the curve's full octet length.
 //
 // RFC 7518 requires x and y to be "the full size of a coordinate for the curve"
-// (https://datatracker.ietf.org/doc/html/rfc7518#section-6.2.1.2), but [big.Int.Bytes] returns the
-// minimal encoding and drops leading zero bytes — which roughly one coordinate in 256 has. A short
-// value is rejected outright by spec-compliant consumers (WebCrypto importKey, jose), while
-// [DecodeEC] reconstructs through [big.Int.SetBytes] and accepts any length, so the defect never
-// surfaces from Go: the package round-trips its own malformed output perfectly.
+// (https://datatracker.ietf.org/doc/html/rfc7518#section-6.2.1.2), while [big.Int.Bytes] drops
+// leading zero bytes — which roughly one coordinate in 256 has. Spec-compliant consumers such as
+// WebCrypto importKey reject the short value, and only they do: [DecodeEC] reads through
+// [big.Int.SetBytes], which accepts any length.
 //
 // FillBytes panics on a value too large for the buffer; callers pass coordinates read off a parsed
 // key, which are on the curve and therefore fit by construction.

--- a/jwk/serializers/ecdsa_test.go
+++ b/jwk/serializers/ecdsa_test.go
@@ -49,13 +49,13 @@ func TestEC(t *testing.T) {
 }
 
 // TestECCoordinateWidth pins the RFC 7518 requirement that x and y are encoded at the curve's full
-// coordinate size rather than big.Int's minimal encoding.
+// coordinate size.
 //
-// The fixture is a P-256 key whose x coordinate happens to be below 2^248, so its minimal encoding
-// is 31 bytes instead of 32. Roughly one coordinate in 256 is like this, which is why a randomly
-// generated key — as the round-trip tests above use — almost never exercises the case, and why the
-// round trip could not catch it anyway: DecodeEC reads through big.Int.SetBytes, which accepts any
-// length. Only a consumer in another runtime rejects the short value.
+// The fixture is a P-256 key whose x coordinate falls below 2^248, so its minimal encoding is 31
+// bytes instead of 32. Roughly one coordinate in 256 is like this, so a randomly generated key
+// almost never exercises it, and a round trip would not catch it either: DecodeEC reads through
+// big.Int.SetBytes, which accepts any length. Only a consumer in another runtime rejects the short
+// value.
 func TestECCoordinateWidth(t *testing.T) {
 	t.Parallel()
 
@@ -70,10 +70,9 @@ func TestECCoordinateWidth(t *testing.T) {
 	privateKey, err := ecdsa.ParseRawPrivateKey(elliptic.P256(), rawKey)
 	require.NoError(t, err)
 
-	// Guard the fixture itself: if this ever stops holding, the test below silently stops testing
-	// anything and must be re-seeded with another short-coordinate key. Read through the
-	// uncompressed point (0x04 || X || Y, fixed width) rather than the deprecated PublicKey.X — a
-	// leading zero byte there is exactly what makes big.Int's minimal encoding come out short.
+	// Guard the fixture: once this stops holding, the test below tests nothing and must be re-seeded
+	// with another short-coordinate key. The check reads the uncompressed point (0x04 || X || Y,
+	// fixed width), whose leading zero byte is what makes big.Int's minimal encoding come out short.
 	rawPoint, err := privateKey.PublicKey.Bytes()
 	require.NoError(t, err)
 	require.Zero(t, rawPoint[1], "fixture no longer has a short x coordinate")

--- a/jwk/serializers/ecdsa_test.go
+++ b/jwk/serializers/ecdsa_test.go
@@ -52,10 +52,9 @@ func TestEC(t *testing.T) {
 // coordinate size.
 //
 // The fixture is a P-256 key whose x coordinate falls below 2^248, so its minimal encoding is 31
-// bytes instead of 32. Roughly one coordinate in 256 is like this, so a randomly generated key
-// almost never exercises it, and a round trip would not catch it either: DecodeEC reads through
-// big.Int.SetBytes, which accepts any length. Only a consumer in another runtime rejects the short
-// value.
+// bytes, one short of the fixed 32. Roughly one coordinate in 256 is like this, so a randomly
+// generated key almost never exercises it. DecodeEC reads through big.Int.SetBytes, which accepts
+// any length, so only a consumer in another runtime rejects the short value.
 func TestECCoordinateWidth(t *testing.T) {
 	t.Parallel()
 

--- a/jwk/source.go
+++ b/jwk/source.go
@@ -37,12 +37,8 @@ type SourceConfig struct {
 	// RetryInterval bounds how often a failing Fetch is retried (negative caching), so a broken
 	// upstream is not hit on every request. Non-positive selects DefaultRetryInterval.
 	RetryInterval time.Duration
-	// RefreshOnUnknownKeyID lets a key id absent from the cache force a fetch, instead of reporting
-	// ErrKeyNotFound against a set that may simply be stale.
-	//
-	// Without it a verifier cannot recognise a key the issuer has rotated to until CacheDuration
-	// elapses on its own schedule; every token signed with the new key is rejected until then, and
-	// the symptom — a wall of 401s that a restart cures — is a reliably misdiagnosed failure.
+	// RefreshOnUnknownKeyID lets a key id absent from the cache force a fetch, so a verifier picks
+	// up a key the issuer has just rotated to without waiting out CacheDuration.
 	//
 	// Off by default because the trigger is attacker-controlled: whoever can present a token chooses
 	// the key id. UnknownKeyIDInterval is what makes it safe to turn on.
@@ -51,24 +47,20 @@ type SourceConfig struct {
 	// a fetch. Non-positive selects DefaultUnknownKeyIDInterval. Ignored unless
 	// RefreshOnUnknownKeyID is set.
 	//
-	// This is the whole rate limit, and it holds regardless of input: a forced fetch resets the
-	// cache age, so every subsequent unknown id within the interval finds the cache too young and
-	// fetches nothing. A flood of distinct forged key ids therefore costs at most one upstream call
-	// per interval — the same as a single one. Tracking which ids were absent would bound nothing
-	// further and would grow with attacker input.
+	// The age check is the whole rate limit, and it holds regardless of input: a forced fetch resets
+	// the cache age, so every subsequent unknown id within the interval finds the cache too young.
+	// A flood of distinct forged key ids therefore costs at most one upstream call per interval.
 	//
-	// The cost of the bound is latency: a genuinely new key id arriving just after a forced fetch
-	// waits up to one interval. That is a different order of magnitude from CacheDuration, which is
-	// the window this exists to close.
+	// The cost is latency: a genuinely new key id arriving just after a forced fetch waits up to one
+	// interval, still far shorter than the CacheDuration window this closes.
 	UnknownKeyIDInterval time.Duration
 }
 
 // A Source fetches and caches the raw JSON Web Keys used to sign or verify tokens, looked up by ID.
 //
-// It is algorithm-agnostic: one Source serves keys of every family a JWK Set holds, and the signer
-// or verifier that consumes it decodes the key material it needs and skips the rest. A mixed set
-// (RSA, EC, HMAC, …) therefore needs a single Source rather than one per key type, which is what
-// lets a recipient verify tokens across an algorithm rotation through one endpoint.
+// It is algorithm-agnostic: one Source serves a mixed set (RSA, EC, HMAC, …), and the signer or
+// verifier that consumes it decodes the key material it needs and skips the rest. That is what lets
+// a recipient verify tokens across an algorithm rotation through one endpoint.
 //
 // It refreshes lazily once the cached set is older than CacheDuration, and is safe for concurrent
 // use.
@@ -83,8 +75,7 @@ type Source struct {
 	mu *sync.RWMutex
 }
 
-// NewSource builds a [Source] from a config. The Source serves raw keys; decoding happens in the
-// signer or verifier that consumes it.
+// NewSource builds a [Source] from a config.
 func NewSource(config SourceConfig) *Source {
 	return &Source{
 		config: config,
@@ -128,8 +119,8 @@ func (source *Source) Get(ctx context.Context, kid string) (*jwa.JWK, error) {
 		return key, nil
 	}
 
-	// An empty kid asks for whichever key ranks first, so a miss means the set is empty rather than
-	// missing a particular key — re-fetching is the caller's business, not a stale-id recovery.
+	// An empty kid asks for whichever key ranks first, so a miss means the set is empty; there is no
+	// stale id to recover from.
 	if kid == "" || !source.config.RefreshOnUnknownKeyID {
 		return nil, fmt.Errorf("(Source.Get) %w", ErrKeyNotFound)
 	}
@@ -150,10 +141,8 @@ func (source *Source) Get(ctx context.Context, kid string) (*jwa.JWK, error) {
 }
 
 // lookup resolves kid against the cache under the read lock, reporting whether it matched. An empty
-// kid resolves to the first (highest-priority) key.
-//
-// It returns the cached pointer rather than a copy: Get yields a single key, so — unlike List — it
-// needs no defensive slice copy, which keeps it cheap on the signing and key-embedding hot paths.
+// kid resolves to the first (highest-priority) key. It hands back the cached pointer, which keeps it
+// cheap on the signing and key-embedding hot paths.
 func (source *Source) lookup(kid string) (*jwa.JWK, bool) {
 	source.mu.RLock()
 	defer source.mu.RUnlock()
@@ -177,9 +166,6 @@ func (source *Source) lookup(kid string) (*jwa.JWK, bool) {
 
 // refreshForUnknownKeyID fetches when the cache is at least UnknownKeyIDInterval old, reporting
 // whether it did.
-//
-// The age check is the rate limit. Because a fetch resets the cache age, concurrent or successive
-// unknown ids collapse into at most one upstream call per interval however many distinct ids arrive.
 func (source *Source) refreshForUnknownKeyID(ctx context.Context) (bool, error) {
 	interval := source.config.UnknownKeyIDInterval
 	if interval <= 0 {
@@ -189,8 +175,8 @@ func (source *Source) refreshForUnknownKeyID(ctx context.Context) (bool, error) 
 	source.mu.Lock()
 	defer source.mu.Unlock()
 
-	// Re-checked under the write lock: another goroutine may have fetched while we queued for it,
-	// which is what collapses a burst of unknown ids into a single call.
+	// Re-checked under the write lock, which collapses a burst of unknown ids queued behind one
+	// another into a single call.
 	if time.Since(source.lastCached) < interval {
 		return false, nil
 	}
@@ -230,18 +216,16 @@ func (source *Source) refresh(ctx context.Context) error {
 
 // fetchLocked replaces the cache from Fetch. The caller must hold the write lock.
 //
-// Both refresh paths go through it so the failure backoff applies whichever one reached it: an
-// unknown key id must not become a way around the negative caching that protects a broken upstream.
+// Both refresh paths go through it, so the failure backoff applies whichever one reached it and an
+// unknown key id stays subject to the negative caching that protects a broken upstream.
 func (source *Source) fetchLocked(ctx context.Context) error {
-	// Negative caching: after a failure, don't call Fetch again until RetryInterval has elapsed, so
-	// a broken upstream isn't hit on every request (a thundering-herd / amplification DoS).
 	retry := source.config.RetryInterval
 	if retry <= 0 {
 		retry = DefaultRetryInterval
 	}
 
-	// Measure the backoff from when a failure is observed, not when the attempt starts: a Fetch that
-	// itself takes longer than retry would otherwise let the next caller re-fetch immediately.
+	// The backoff runs from when the failure was observed, so a Fetch slower than retry still holds
+	// the next caller off for a full interval.
 	if source.lastErr != nil && time.Since(source.lastFailure) < retry {
 		return source.lastErr
 	}
@@ -255,8 +239,8 @@ func (source *Source) fetchLocked(ctx context.Context) error {
 	}
 
 	// Copy the returned slice before caching so a Fetch that reuses or later mutates its backing
-	// array can't corrupt the cache. make(...) also keeps the cache non-nil for an empty result, so
-	// an empty key set still reads as fresh rather than re-fetching on every request.
+	// array cannot corrupt the cache. make(...) also keeps the cache non-nil for an empty result, so
+	// an empty key set still reads as fresh.
 	cached := make([]*jwa.JWK, len(keys))
 	copy(cached, keys)
 

--- a/jwk/source_test.go
+++ b/jwk/source_test.go
@@ -156,7 +156,7 @@ func TestSourceRefresh(t *testing.T) {
 	}
 
 	fetcher := func(_ context.Context) ([]*jwa.JWK, error) {
-		// Copy the slice to prevent side effects.
+		// Copy the slice so a caller cannot mutate the fixture.
 		copied := make([]*jwa.JWK, len(keys))
 		copy(copied, keys)
 
@@ -216,8 +216,7 @@ func TestSourceNegativeCache(t *testing.T) {
 
 	source := jwk.NewSource(config)
 
-	// Two failing List calls: Fetch must run only once — the second is served from the negative
-	// cache instead of hammering the upstream.
+	// Two failing List calls: the second is served from the negative cache, so Fetch runs once.
 	_, err := source.List(t.Context())
 	require.ErrorIs(t, err, errFoo)
 
@@ -253,8 +252,8 @@ func TestSourceCaches(t *testing.T) {
 	require.Equal(t, 1, fetchCount)
 }
 
-// Tests for RefreshOnUnknownKeyID: a key id absent from the cache forcing a bounded fetch, so a
-// verifier finds a key the issuer has just rotated to instead of waiting out CacheDuration.
+// Tests for RefreshOnUnknownKeyID: a key id absent from the cache forces a bounded fetch, so a
+// verifier finds a key the issuer has just rotated to without waiting out CacheDuration.
 
 func TestSourceGetUnknownKeyIDDisabled(t *testing.T) {
 	t.Parallel()
@@ -273,8 +272,7 @@ func TestSourceGetUnknownKeyIDDisabled(t *testing.T) {
 	_, err := source.Get(t.Context(), "kid-1")
 	require.NoError(t, err)
 
-	// The default must be untouched: an unknown id reports the miss against the cached set without
-	// going upstream, however old that set is.
+	// By default an unknown id reports the miss against the cached set, however old that set is.
 	_, err = source.Get(t.Context(), "rotated-kid")
 	require.ErrorIs(t, err, jwk.ErrKeyNotFound)
 	require.EqualValues(t, 1, fetches.Load())
@@ -309,8 +307,7 @@ func TestSourceGetUnknownKeyIDRefreshes(t *testing.T) {
 	require.NoError(t, err)
 	require.EqualValues(t, 1, fetches.Load())
 
-	// The issuer rotates. CacheDuration has not elapsed, so without this feature the new key stays
-	// invisible for an hour.
+	// The issuer rotates. CacheDuration has not elapsed, so only a forced fetch reveals the new key.
 	rotated.Store(true)
 
 	key, err := source.Get(t.Context(), "kid-2")
@@ -339,13 +336,9 @@ func TestSourceGetUnknownKeyIDRateLimited(t *testing.T) {
 	require.NoError(t, err)
 	require.EqualValues(t, 1, fetches.Load())
 
-	// The trigger is attacker-controlled: whoever presents a token picks the key id. A flood of
-	// distinct forged ids must not amplify into a flood of upstream calls.
-	//
-	// Nothing at all goes upstream here, because the bound is the cache's age rather than a count:
-	// the set was just fetched, so no id is old enough to justify re-fetching. The amplification
-	// factor is zero for as long as the interval holds, and one fetch per interval after that —
-	// independent of how many distinct ids arrive.
+	// The trigger is attacker-controlled: whoever presents a token picks the key id. The bound is the
+	// cache's age, so a flood of distinct forged ids costs at most one upstream call per interval —
+	// and none at all here, where the set was just fetched.
 	for i := range 500 {
 		_, err = source.Get(t.Context(), "forged-"+strconv.Itoa(i))
 		require.ErrorIs(t, err, jwk.ErrKeyNotFound)
@@ -373,8 +366,8 @@ func TestSourceGetUnknownKeyIDConcurrent(t *testing.T) {
 	_, err := source.Get(t.Context(), "kid-1")
 	require.NoError(t, err)
 
-	// Same bound under contention: the age is re-checked under the write lock, so goroutines that
-	// queue behind one another find the cache young rather than each fetching in turn.
+	// Same bound under contention: the age is re-checked under the write lock, so goroutines queued
+	// behind one another find the cache young.
 	var wg sync.WaitGroup
 
 	for i := range 50 {
@@ -421,8 +414,8 @@ func TestSourceGetUnknownKeyIDHonoursBackoff(t *testing.T) {
 	require.ErrorIs(t, err, errUpstream)
 	require.EqualValues(t, 2, fetches.Load())
 
-	// An unknown key id must not be a way around the retry backoff — otherwise the negative caching
-	// that protects a broken upstream is bypassed by the one input an attacker controls.
+	// An unknown key id stays subject to the retry backoff, so the one attacker-controlled input
+	// cannot bypass the negative caching that protects a broken upstream.
 	_, err = source.Get(t.Context(), "forged-2")
 	require.ErrorIs(t, err, errUpstream)
 	require.EqualValues(t, 2, fetches.Load(), "the backoff must hold on the unknown-key-id path")

--- a/jwp/claims_checker.go
+++ b/jwp/claims_checker.go
@@ -44,7 +44,7 @@ func NewClaimsCheckTarget(target jwt.TargetConfig) *ClaimsCheckTarget {
 func (claimsCheck *ClaimsCheckTarget) CheckClaims(claims *jwa.Claims) error {
 	// RFC 7519 §4.1.3: the recipient identifies with a value in the token's audience. The check
 	// passes when any configured audience appears in the token's aud; an empty target audience opts
-	// out of the check (matching go-jose / golang-jwt).
+	// out of the check.
 	if len(claimsCheck.target.Audience) > 0 && !audienceContainsAny(claims.Aud, claimsCheck.target.Audience) {
 		return fmt.Errorf(
 			"invalid audience %v, expected one of %v",
@@ -195,8 +195,8 @@ func (checker *ClaimsChecker) Unmarshal(raw []byte, dst any) error {
 		}
 	}
 
-	// Fall back to json.Unmarshal via a local variable, never by writing config: a first-call write
-	// to a shared checker would be a data race, and a zero-value checker must still work.
+	// Resolve the fallback into a local, so a zero-value checker works and concurrent callers never
+	// write the shared config.
 	deserialize := checker.config.Deserializer
 	if deserialize == nil {
 		deserialize = json.Unmarshal

--- a/jwp/claims_checker_test.go
+++ b/jwp/claims_checker_test.go
@@ -329,8 +329,7 @@ func TestClaimsCheckerCustomDeserializer(t *testing.T) {
 
 	var dst map[string]any
 
-	// The configured Deserializer must actually run — it used to be dropped for a hardcoded
-	// json.Unmarshal.
+	// A configured Deserializer runs in place of json.Unmarshal.
 	require.NoError(t, checker.Unmarshal([]byte(`{"foo":"bar"}`), &dst))
 	require.True(t, called, "configured Deserializer should be used")
 	require.Equal(t, map[string]any{"foo": "bar"}, dst)
@@ -339,7 +338,7 @@ func TestClaimsCheckerCustomDeserializer(t *testing.T) {
 func TestClaimsCheckerNilDeserializer(t *testing.T) {
 	t.Parallel()
 
-	// A checker with no configured Deserializer must fall back to json.Unmarshal, not panic.
+	// A checker with no configured Deserializer falls back to json.Unmarshal.
 	checker := jwp.NewClaimsChecker(&jwp.ClaimsCheckerConfig{})
 
 	var dst map[string]any

--- a/jws/assertions.go
+++ b/jws/assertions.go
@@ -3,8 +3,7 @@ package jws
 import "github.com/a-novel-kit/jwt/v2"
 
 // Compile-time checks that every signer and verifier satisfies the plugin contract it is wired in
-// as. A signature drift is then caught at build time rather than at a call site (or, worse, only
-// once a caller tries to use it — as happened for a CEK manager before these guards existed).
+// as, so a drifting method signature fails the build instead of a call site.
 var (
 	_ jwt.ProducerPlugin = (*HMACSigner)(nil)
 	_ jwt.ProducerPlugin = (*SourcedHMACSigner)(nil)

--- a/jws/assertions.go
+++ b/jws/assertions.go
@@ -3,7 +3,7 @@ package jws
 import "github.com/a-novel-kit/jwt/v2"
 
 // Compile-time checks that every signer and verifier satisfies the plugin contract it is wired in
-// as, so a drifting method signature fails the build instead of a call site.
+// as, so a drifting method signature fails the build.
 var (
 	_ jwt.ProducerPlugin = (*HMACSigner)(nil)
 	_ jwt.ProducerPlugin = (*SourcedHMACSigner)(nil)

--- a/jws/common.go
+++ b/jws/common.go
@@ -22,8 +22,8 @@ var ErrUnsupportedAlgorithm = errors.New("unsupported algorithm")
 const minRSAKeyBits = 2048
 
 // checkRSAPublicKey fails closed unless key is a usable RSA public key: non-nil, with a positive
-// modulus of at least minRSAKeyBits. The sign check is its own test because BitLen reads the
-// absolute value, so a negative modulus would otherwise clear the floor.
+// modulus of at least minRSAKeyBits. BitLen reads the absolute value, so the sign is checked
+// separately. A negative modulus clears the bit-length floor.
 func checkRSAPublicKey(key *rsa.PublicKey) error {
 	if key == nil || key.N == nil || key.N.Sign() <= 0 {
 		return fmt.Errorf("%w: RSA key has no valid modulus", jwt.ErrInvalidSecretKey)

--- a/jws/common.go
+++ b/jws/common.go
@@ -22,9 +22,8 @@ var ErrUnsupportedAlgorithm = errors.New("unsupported algorithm")
 const minRSAKeyBits = 2048
 
 // checkRSAPublicKey fails closed unless key is a usable RSA public key: non-nil, with a positive
-// modulus of at least minRSAKeyBits. It rejects nil, non-positive (BitLen reads the absolute value,
-// so a negative modulus would otherwise pass), and sub-floor moduli, so no invalid key reaches
-// crypto/rsa where the failure would be later and less clear.
+// modulus of at least minRSAKeyBits. The sign check is its own test because BitLen reads the
+// absolute value, so a negative modulus would otherwise clear the floor.
 func checkRSAPublicKey(key *rsa.PublicKey) error {
 	if key == nil || key.N == nil || key.N.Sign() <= 0 {
 		return fmt.Errorf("%w: RSA key has no valid modulus", jwt.ErrInvalidSecretKey)

--- a/jws/ecdsa.go
+++ b/jws/ecdsa.go
@@ -16,8 +16,7 @@ import (
 )
 
 // An ECDSAPreset bundles the curve, hash, and algorithm identifier for one ECDSA signing scheme.
-// Pass one of the exported presets to the ECDSA constructors rather than assembling the fields by
-// hand.
+// Pass one of the exported presets to the ECDSA constructors.
 type ECDSAPreset struct {
 	Hash crypto.Hash
 	Alg  jwa.Alg
@@ -187,8 +186,7 @@ func (verifier *ECDSAVerifier) Transform(_ context.Context, header *jwa.JWH, raw
 }
 
 // sourcedECDSAPublic decodes a raw JSON Web Key into an ECDSA public key for verification, matching
-// only signature keys on the preset's algorithm and curve, skipping any that carry private material
-// (signing keys, which a verifier does not use).
+// only signature keys on the preset's algorithm and curve, skipping any that carry private material.
 func sourcedECDSAPublic(preset ECDSAPreset) keyDecoder[*ecdsa.PublicKey] {
 	jwkPreset := jwk.ECDSAPreset{Alg: preset.Alg, Curve: preset.Crv}
 
@@ -229,8 +227,7 @@ func sourcedECDSAPrivate(preset ECDSAPreset) keyDecoder[*ecdsa.PrivateKey] {
 }
 
 // A SourcedECDSASigner signs like an [ECDSASigner] but resolves its key from a [jwk.Source] at each
-// call, so the plugin follows key rotation instead of pinning one key. Build one with
-// [NewSourcedECDSASigner].
+// call, so the plugin follows key rotation. Build one with [NewSourcedECDSASigner].
 type SourcedECDSASigner struct {
 	source *jwk.Source
 	preset ECDSAPreset

--- a/jws/ecdsa_test.go
+++ b/jws/ecdsa_test.go
@@ -154,7 +154,6 @@ func TestECDSASourcedSigner(t *testing.T) {
 			token, err := producer.Issue(t.Context(), producerClaims, nil)
 			require.NoError(t, err)
 
-			// OK.
 			t.Run("TryFirstKey", func(t *testing.T) {
 				recipient := jwt.NewRecipient(jwt.RecipientConfig{
 					Plugins: []jwt.RecipientPlugin{jws.NewECDSAVerifier(publicKeys[0].Key(), testCase.preset)},
@@ -166,7 +165,6 @@ func TestECDSASourcedSigner(t *testing.T) {
 				require.Equal(t, producerClaims, recipientClaims)
 			})
 
-			// KO.
 			t.Run("TrySecondKey", func(t *testing.T) {
 				recipient := jwt.NewRecipient(jwt.RecipientConfig{
 					Plugins: []jwt.RecipientPlugin{jws.NewECDSAVerifier(publicKeys[1].Key(), testCase.preset)},
@@ -236,7 +234,6 @@ func TestECDSASourcedVerifier(t *testing.T) {
 			token, err := producer.Issue(t.Context(), producerClaims, nil)
 			require.NoError(t, err)
 
-			// OK.
 			t.Run("SigningKeyFirst", func(t *testing.T) {
 				recipient := jwt.NewRecipient(jwt.RecipientConfig{
 					Plugins: []jwt.RecipientPlugin{jws.NewSourcedECDSAVerifier(source, testCase.preset)},
@@ -248,7 +245,6 @@ func TestECDSASourcedVerifier(t *testing.T) {
 				require.Equal(t, producerClaims, recipientClaims)
 			})
 
-			// OK.
 			t.Run("SigningKeySecond", func(t *testing.T) {
 				_, newPublicKey, err := jwk.GenerateECDSA(testCase.keyPreset)
 				require.NoError(t, err)
@@ -268,7 +264,6 @@ func TestECDSASourcedVerifier(t *testing.T) {
 				require.Equal(t, producerClaims, recipientClaims)
 			})
 
-			// KO.
 			t.Run("KeyMissing", func(t *testing.T) {
 				_, newPublicKey, err := jwk.GenerateECDSA(testCase.keyPreset)
 				require.NoError(t, err)

--- a/jws/ed25519.go
+++ b/jws/ed25519.go
@@ -99,7 +99,7 @@ func (verifier *ED25519Verifier) Transform(_ context.Context, header *jwa.JWH, r
 }
 
 // sourcedED25519Public decodes a raw JSON Web Key into an Ed25519 public key for verification,
-// skipping any that carry private material (signing keys, which a verifier does not use).
+// skipping any that carry private material.
 func sourcedED25519Public() keyDecoder[ed25519.PublicKey] {
 	return func(key *jwa.JWK) (ed25519.PublicKey, error) {
 		privateKey, publicKey, err := jwk.ConsumeED25519(key)
@@ -136,8 +136,7 @@ func sourcedED25519Private() keyDecoder[ed25519.PrivateKey] {
 }
 
 // A SourcedED25519Signer signs like an [ED25519Signer] but resolves its key from a [jwk.Source] at
-// each call, so the plugin follows key rotation instead of pinning one key. Build one with
-// [NewSourcedED25519Signer].
+// each call, so the plugin follows key rotation. Build one with [NewSourcedED25519Signer].
 type SourcedED25519Signer struct {
 	source *jwk.Source
 }

--- a/jws/ed25519_test.go
+++ b/jws/ed25519_test.go
@@ -104,7 +104,6 @@ func TestED25519SourcedSigner(t *testing.T) {
 	token, err := producer.Issue(t.Context(), producerClaims, nil)
 	require.NoError(t, err)
 
-	// OK.
 	t.Run("TryFirstKey", func(t *testing.T) {
 		t.Parallel()
 
@@ -118,7 +117,6 @@ func TestED25519SourcedSigner(t *testing.T) {
 		require.Equal(t, producerClaims, recipientClaims)
 	})
 
-	// KO.
 	t.Run("TrySecondKey", func(t *testing.T) {
 		t.Parallel()
 
@@ -161,7 +159,6 @@ func TestED25519SourcedVerifier(t *testing.T) {
 	token, err := producer.Issue(t.Context(), producerClaims, nil)
 	require.NoError(t, err)
 
-	// OK.
 	t.Run("SigningKeyFirst", func(t *testing.T) {
 		t.Parallel()
 
@@ -175,7 +172,6 @@ func TestED25519SourcedVerifier(t *testing.T) {
 		require.Equal(t, producerClaims, recipientClaims)
 	})
 
-	// OK.
 	t.Run("SigningKeySecond", func(t *testing.T) {
 		t.Parallel()
 
@@ -197,7 +193,6 @@ func TestED25519SourcedVerifier(t *testing.T) {
 		require.Equal(t, producerClaims, recipientClaims)
 	})
 
-	// KO.
 	t.Run("KeyMissing", func(t *testing.T) {
 		t.Parallel()
 

--- a/jws/hmac.go
+++ b/jws/hmac.go
@@ -13,7 +13,7 @@ import (
 )
 
 // An HMACPreset bundles the hash and algorithm identifier for one HMAC signing scheme. Pass one of
-// the exported presets to the HMAC constructors rather than assembling the fields by hand.
+// the exported presets to the HMAC constructors.
 type HMACPreset struct {
 	Hash crypto.Hash
 	Alg  jwa.Alg
@@ -76,8 +76,8 @@ func (signer *HMACSigner) Header(_ context.Context, header *jwa.JWH) (*jwa.JWH, 
 }
 
 func (signer *HMACSigner) Transform(_ context.Context, _ *jwa.JWH, tokenRaw string) (string, error) {
-	// Re-check on the signing path too: a sourced signer re-resolves its key here without going
-	// back through Header, so this is the only guard that actually gates every signature.
+	// A sourced signer re-resolves its key here without going back through Header, so this is the
+	// guard that gates every signature.
 	if len(signer.secretKey) < signer.hash.Size() {
 		return "", fmt.Errorf(
 			"(HMACSigner.Transform) %w: HMAC key is %d bytes, need at least %d (RFC 7518 §3.2)",
@@ -182,8 +182,7 @@ func sourcedHMACKey(alg jwa.Alg) keyDecoder[[]byte] {
 }
 
 // A SourcedHMACSigner signs like an [HMACSigner] but resolves its secret from a [jwk.Source] at each
-// call, so the plugin follows key rotation instead of pinning one secret. Build one with
-// [NewSourcedHMACSigner].
+// call, so the plugin follows key rotation. Build one with [NewSourcedHMACSigner].
 type SourcedHMACSigner struct {
 	source *jwk.Source
 	preset HMACPreset

--- a/jws/hmac_test.go
+++ b/jws/hmac_test.go
@@ -157,7 +157,6 @@ func TestHMACSourcedSigner(t *testing.T) {
 			token, err := producer.Issue(t.Context(), producerClaims, nil)
 			require.NoError(t, err)
 
-			// OK.
 			t.Run("TryFirstKey", func(t *testing.T) {
 				t.Parallel()
 
@@ -171,7 +170,6 @@ func TestHMACSourcedSigner(t *testing.T) {
 				require.Equal(t, producerClaims, recipientClaims)
 			})
 
-			// KO.
 			t.Run("TrySecondKey", func(t *testing.T) {
 				t.Parallel()
 
@@ -241,7 +239,6 @@ func TestHMACSourcedVerifier(t *testing.T) {
 			token, err := producer.Issue(t.Context(), producerClaims, nil)
 			require.NoError(t, err)
 
-			// OK.
 			t.Run("SigningKeyFirst", func(t *testing.T) {
 				t.Parallel()
 
@@ -255,7 +252,6 @@ func TestHMACSourcedVerifier(t *testing.T) {
 				require.Equal(t, producerClaims, recipientClaims)
 			})
 
-			// OK.
 			t.Run("SigningKeySecond", func(t *testing.T) {
 				t.Parallel()
 
@@ -277,7 +273,6 @@ func TestHMACSourcedVerifier(t *testing.T) {
 				require.Equal(t, producerClaims, recipientClaims)
 			})
 
-			// KO.
 			t.Run("KeyMissing", func(t *testing.T) {
 				t.Parallel()
 

--- a/jws/rotation_test.go
+++ b/jws/rotation_test.go
@@ -116,9 +116,8 @@ func TestSourcedVerifierSurfacesMalformedKey(t *testing.T) {
 }
 
 // TestSourcedRotationUnknownKeyID is the acceptance test for RefreshOnUnknownKeyID on the path a
-// recipient actually takes: verifyFromSource walks Source.List, so a refresh wired only into
-// Source.Get would leave it reading a stale set, skipping every key whose id misses the header, and
-// reporting an invalid signature for the whole of CacheDuration.
+// recipient actually takes. verifyFromSource walks Source.List. The refresh has to reach List for
+// a rotated key to be found inside CacheDuration.
 func TestSourcedRotationUnknownKeyID(t *testing.T) {
 	t.Parallel()
 

--- a/jws/rotation_test.go
+++ b/jws/rotation_test.go
@@ -17,10 +17,10 @@ import (
 
 // TestSourcedMixedRotation is the acceptance test for the raw source: one Source serves keys of two
 // families, and a single recipient — configured with a verifier per accepted algorithm — verifies
-// tokens of both through the same code, routing on the header's alg. This is the shape an algorithm
-// rotation takes: keep verifiers for the old and new algorithms while both keys live, and the same
-// endpoint accepts either. A token whose algorithm has no configured verifier is rejected, so the
-// header can only route among the verifiers the operator pinned — never introduce a new algorithm.
+// tokens of both, routing on the header's alg. That is the shape of an algorithm rotation: keep
+// verifiers for the old and new algorithms while both keys live. A token whose algorithm has no
+// configured verifier is rejected, so the header routes only among the verifiers the operator
+// pinned.
 func TestSourcedMixedRotation(t *testing.T) {
 	t.Parallel()
 
@@ -115,13 +115,10 @@ func TestSourcedVerifierSurfacesMalformedKey(t *testing.T) {
 	require.NotErrorIs(t, err, jws.ErrInvalidSignature)
 }
 
-// TestSourcedRotationUnknownKeyID is the acceptance test for RefreshOnUnknownKeyID, and it exercises
-// the path the defect actually lived on.
-//
-// verifyFromSource reads through Source.List, not Source.Get, so a source that only re-fetched on a
-// Get miss would have changed nothing here: the verifier would still walk a stale set, skip every key
-// whose id does not match the header, and report an invalid signature. That is the failure this
-// closes — a wall of 401s, after an ordinary key rotation, that a restart cures.
+// TestSourcedRotationUnknownKeyID is the acceptance test for RefreshOnUnknownKeyID on the path a
+// recipient actually takes: verifyFromSource walks Source.List, so a refresh wired only into
+// Source.Get would leave it reading a stale set, skipping every key whose id misses the header, and
+// reporting an invalid signature for the whole of CacheDuration.
 func TestSourcedRotationUnknownKeyID(t *testing.T) {
 	t.Parallel()
 
@@ -133,7 +130,7 @@ func TestSourcedRotationUnknownKeyID(t *testing.T) {
 
 	claims := map[string]any{"foo": "bar"}
 
-	// The issuer signs with whichever key it currently holds, naming it in the header — which is what
+	// The issuer signs with whichever key it currently holds, naming it in the header, which is what
 	// gives the consumer an id to miss on.
 	issue := func(t *testing.T, key *jwk.Key[*rsa.PrivateKey]) string {
 		t.Helper()

--- a/jws/rsa.go
+++ b/jws/rsa.go
@@ -15,9 +15,8 @@ import (
 )
 
 // An RSAPreset bundles the hash and algorithm identifier for one RSA signing scheme. Pass one of the
-// exported presets to the RSA constructors rather than assembling the fields by hand: the RS* presets
-// use RSASSA-PKCS1-v1_5, the PS* presets use RSASSA-PSS. The algorithm alone determines the scheme,
-// so there is no separate field to keep consistent. Both run on the same RSA keys.
+// exported presets to the RSA constructors: the RS* presets use RSASSA-PKCS1-v1_5, the PS* presets
+// use RSASSA-PSS, and both run on the same RSA keys.
 type RSAPreset struct {
 	Hash crypto.Hash
 	Alg  jwa.Alg
@@ -38,9 +37,8 @@ var (
 	PS512 = RSAPreset{Hash: crypto.SHA512, Alg: jwa.PS512}
 )
 
-// algIsPSS reports whether alg denotes RSASSA-PSS rather than RSASSA-PKCS1-v1_5. It errors for any
-// algorithm that is not an RSA signing algorithm, so a preset assembled by hand with an alg that
-// names no real RSA scheme fails loudly instead of signing under a mismatched one.
+// algIsPSS reports whether alg selects RSASSA-PSS. It returns [ErrUnsupportedAlgorithm] for anything
+// that is not an RS* or PS* algorithm, so a hand-assembled preset fails before it signs.
 func algIsPSS(alg jwa.Alg) (bool, error) {
 	switch alg {
 	case jwa.RS256, jwa.RS384, jwa.RS512:
@@ -90,8 +88,8 @@ func (signer *RSASigner) Header(_ context.Context, header *jwa.JWH) (*jwa.JWH, e
 }
 
 func (signer *RSASigner) Transform(_ context.Context, _ *jwa.JWH, tokenRaw string) (string, error) {
-	// Re-check on the signing path too: a sourced signer re-resolves its key here without going
-	// back through Header, so this is the only guard that actually gates every signature.
+	// A sourced signer re-resolves its key here without going back through Header, so this is the
+	// guard that gates every signature.
 	err := checkRSAPrivateKey(signer.secretKey)
 	if err != nil {
 		return "", fmt.Errorf("(RSASigner.Transform) %w", err)
@@ -221,8 +219,7 @@ func (verifier *RSAVerifier) verify(digest, sig []byte) error {
 }
 
 // sourcedRSAPublic decodes a raw JSON Web Key into an RSA public key for verification, matching only
-// signature keys bound to alg and skipping any that carry private material (signing keys, which a
-// verifier does not use). It backs the sourced RSA verifiers for every RS*/PS* alg.
+// signature keys bound to alg and skipping any that carry private material.
 func sourcedRSAPublic(alg jwa.Alg) keyDecoder[*rsa.PublicKey] {
 	preset := jwk.RSAPreset{
 		Alg:           alg,
@@ -274,8 +271,7 @@ func sourcedRSAPrivate(alg jwa.Alg) keyDecoder[*rsa.PrivateKey] {
 }
 
 // A SourcedRSASigner signs like an [RSASigner] but resolves its key from a [jwk.Source] at each
-// call, so the plugin follows key rotation instead of pinning one key. Build one with
-// [NewSourcedRSASigner].
+// call, so the plugin follows key rotation. Build one with [NewSourcedRSASigner].
 type SourcedRSASigner struct {
 	source *jwk.Source
 	preset RSAPreset

--- a/jws/rsa_pss_test.go
+++ b/jws/rsa_pss_test.go
@@ -160,7 +160,6 @@ func TestRSAPSSSourcedSigner(t *testing.T) {
 			token, err := producer.Issue(t.Context(), producerClaims, nil)
 			require.NoError(t, err)
 
-			// OK.
 			t.Run("TryFirstKey", func(t *testing.T) {
 				t.Parallel()
 
@@ -174,7 +173,6 @@ func TestRSAPSSSourcedSigner(t *testing.T) {
 				require.Equal(t, producerClaims, recipientClaims)
 			})
 
-			// KO.
 			t.Run("TrySecondKey", func(t *testing.T) {
 				t.Parallel()
 
@@ -246,7 +244,6 @@ func TestRSAPSSSourcedVerifier(t *testing.T) {
 			token, err := producer.Issue(t.Context(), producerClaims, nil)
 			require.NoError(t, err)
 
-			// OK.
 			t.Run("SigningKeyFirst", func(t *testing.T) {
 				t.Parallel()
 
@@ -260,7 +257,6 @@ func TestRSAPSSSourcedVerifier(t *testing.T) {
 				require.Equal(t, producerClaims, recipientClaims)
 			})
 
-			// OK.
 			t.Run("SigningKeySecond", func(t *testing.T) {
 				t.Parallel()
 
@@ -282,7 +278,6 @@ func TestRSAPSSSourcedVerifier(t *testing.T) {
 				require.Equal(t, producerClaims, recipientClaims)
 			})
 
-			// KO.
 			t.Run("KeyMissing", func(t *testing.T) {
 				t.Parallel()
 

--- a/jws/rsa_test.go
+++ b/jws/rsa_test.go
@@ -162,7 +162,6 @@ func TestRSASourcedSigner(t *testing.T) {
 			token, err := producer.Issue(t.Context(), producerClaims, nil)
 			require.NoError(t, err)
 
-			// OK.
 			t.Run("TryFirstKey", func(t *testing.T) {
 				t.Parallel()
 
@@ -176,7 +175,6 @@ func TestRSASourcedSigner(t *testing.T) {
 				require.Equal(t, producerClaims, recipientClaims)
 			})
 
-			// KO.
 			t.Run("TrySecondKey", func(t *testing.T) {
 				t.Parallel()
 
@@ -248,7 +246,6 @@ func TestRSASourcedVerifier(t *testing.T) {
 			token, err := producer.Issue(t.Context(), producerClaims, nil)
 			require.NoError(t, err)
 
-			// OK.
 			t.Run("SigningKeyFirst", func(t *testing.T) {
 				t.Parallel()
 
@@ -262,7 +259,6 @@ func TestRSASourcedVerifier(t *testing.T) {
 				require.Equal(t, producerClaims, recipientClaims)
 			})
 
-			// OK.
 			t.Run("SigningKeySecond", func(t *testing.T) {
 				t.Parallel()
 
@@ -284,7 +280,6 @@ func TestRSASourcedVerifier(t *testing.T) {
 				require.Equal(t, producerClaims, recipientClaims)
 			})
 
-			// KO.
 			t.Run("KeyMissing", func(t *testing.T) {
 				t.Parallel()
 
@@ -336,8 +331,8 @@ func TestRSACrossSchemeRejected(t *testing.T) {
 
 	var dst map[string]any
 
-	// A PKCS1v15 (RS*) token must not verify with a PSS (PS*) verifier, and vice versa — each verifier
-	// is pinned to its preset's alg, so the two schemes never cross.
+	// Each verifier is pinned to its preset's alg, so a PKCS1v15 (RS*) token and a PSS (PS*) verifier
+	// never match.
 	require.Error(t, psVerifier.Consume(t.Context(), rsToken, &dst))
 	require.Error(t, rsVerifier.Consume(t.Context(), psToken, &dst))
 
@@ -352,8 +347,7 @@ func TestRSAUnknownAlgorithmRejected(t *testing.T) {
 	privateKey, _, err := jwk.GenerateRSA(jwk.RS256)
 	require.NoError(t, err)
 
-	// A hand-built preset whose algorithm is neither RS* nor PS* must fail loudly at signing, not
-	// silently sign under PKCS1v15 with a bogus header alg.
+	// A hand-built preset whose algorithm is neither RS* nor PS* fails at signing.
 	signer := jws.NewRSASigner(privateKey.Key(), jws.RSAPreset{Hash: crypto.SHA256, Alg: jwa.Alg("RS999")})
 	producer := jwt.NewProducer(jwt.ProducerConfig{Plugins: []jwt.ProducerPlugin{signer}})
 

--- a/jws/sourced.go
+++ b/jws/sourced.go
@@ -140,8 +140,8 @@ func signFromSource[K any](
 	for _, candidate := range keys {
 		key, decodeErr := decode(candidate)
 		if decodeErr != nil {
-			// Skip keys of another family. A malformed key of this family surfaces as an error, since
-			// keys are listed in priority order and falling through would sign with a lesser one.
+			// Skip keys of another family. Keys are listed in priority order, and the first match is the
+			// one to sign with. A malformed key of this family is an error.
 			if errors.Is(decodeErr, jwk.ErrJWKMismatch) {
 				continue
 			}

--- a/jws/sourced.go
+++ b/jws/sourced.go
@@ -16,9 +16,8 @@ import (
 type keyDecoder[K any] func(key *jwa.JWK) (K, error)
 
 // verifyFromSource tries each key the source lists, honoring a KID hint, until one verifies the
-// token or every candidate fails. decode turns a raw key into this verifier's native type (erroring
-// on keys from another family, which are skipped); newVerifier builds a single-key verifier. It
-// centralizes the loop the Sourced*Verifier types all share.
+// token or every candidate fails. decode turns a raw key into this verifier's native type, erroring
+// on keys from another family, which are skipped; newVerifier builds a single-key verifier.
 func verifyFromSource[K any](
 	ctx context.Context,
 	source *jwk.Source,
@@ -27,14 +26,13 @@ func verifyFromSource[K any](
 	decode keyDecoder[K],
 	newVerifier func(key K) jwt.RecipientPlugin,
 ) ([]byte, error) {
-	// try reports whether candidate verified the token. A nil payload with a nil error means the
-	// candidate was not this verifier's to use, or did not verify — either way, keep looking.
+	// try verifies the token with candidate. A nil payload and a nil error means the candidate was
+	// not this verifier's to use, or did not verify — either way, keep looking.
 	try := func(candidate *jwa.JWK) ([]byte, error) {
 		key, decodeErr := decode(candidate)
 		if decodeErr != nil {
-			// A key of another algorithm family is not this verifier's to use — skip it. But a key of
-			// the right family that fails to decode (malformed material) is a real error to surface,
-			// not one to mask as an invalid signature.
+			// Skip a key of another algorithm family. A key of this family that fails to decode is
+			// malformed material, and surfaces as an error of its own.
 			if errors.Is(decodeErr, jwk.ErrJWKMismatch) {
 				return nil, nil
 			}
@@ -79,19 +77,16 @@ func verifyFromSource[K any](
 		}
 	}
 
-	// Every candidate the cached set offered has been tried.
 	if header.KID == "" || named {
 		return nil, fmt.Errorf("(verifyFromSource) %w", ErrInvalidSignature)
 	}
 
-	// The token names a key id the cached set does not hold. That is what a rotation looks like from
-	// here — the issuer has moved on and this set predates it — so ask the source for the id directly
-	// rather than concluding the signature is invalid. The source decides whether to go upstream;
-	// with RefreshOnUnknownKeyID unset this is a cache scan that changes nothing.
+	// The token names a key id the cached set does not hold, which is how a rotation looks from here,
+	// so ask the source for the id directly. The source decides whether to go upstream; with
+	// RefreshOnUnknownKeyID unset this is a cache scan that changes nothing.
 	candidate, err := source.Get(ctx, header.KID)
 	if err != nil {
-		// Still unknown after the source has had its say: the signature is unverifiable, which is
-		// what the caller needs to hear.
+		// Still unknown after the source has had its say, so the signature is unverifiable.
 		if errors.Is(err, jwk.ErrKeyNotFound) {
 			return nil, fmt.Errorf("(verifyFromSource) %w", ErrInvalidSignature)
 		}
@@ -112,10 +107,9 @@ func verifyFromSource[K any](
 }
 
 // signFromSource resolves the key a sourced signer should use: the one matching kid, or — when kid
-// is empty — the first key that decodes to this signer's family (skipping other families a mixed
-// source holds). It returns the decoded key and the resolved key's ID so the signer can stamp the
-// header. Selection never consults anything the token header carries beyond an explicit kid, so the
-// signer stays pinned to its own algorithm.
+// is empty — the first key that decodes to this signer's family. It returns the decoded key and the
+// resolved key's ID so the signer can stamp the header. Selection consults nothing in the token
+// header beyond an explicit kid, so the signer stays pinned to its own algorithm.
 func signFromSource[K any](
 	ctx context.Context,
 	source *jwk.Source,
@@ -146,8 +140,8 @@ func signFromSource[K any](
 	for _, candidate := range keys {
 		key, decodeErr := decode(candidate)
 		if decodeErr != nil {
-			// Skip keys of another family, but surface a malformed key of this family rather than
-			// silently falling back to a lower-priority one — keys are listed in priority order.
+			// Skip keys of another family. A malformed key of this family surfaces as an error, since
+			// keys are listed in priority order and falling through would sign with a lesser one.
 			if errors.Is(decodeErr, jwk.ErrJWKMismatch) {
 				continue
 			}

--- a/producer_claims.go
+++ b/producer_claims.go
@@ -24,7 +24,7 @@ type TargetConfig struct {
 	Subject string
 }
 
-// ClaimsProducerConfig is a configuration struct used to issue standardized claims.
+// ClaimsProducerConfig scopes and time-bounds the claims a producer stamps on every token.
 type ClaimsProducerConfig struct {
 	TargetConfig
 

--- a/recipient.go
+++ b/recipient.go
@@ -11,9 +11,8 @@ import (
 )
 
 // DefaultMaxTokenBytes bounds the size of an untrusted token Consume will parse when the
-// RecipientConfig does not set a limit. It is deliberately generous — even a JWE carrying an
-// embedded certificate chain stays well under it — while capping the work an attacker can force
-// with an oversized input.
+// RecipientConfig does not set a limit. It caps the work an oversized input can force while staying
+// well clear of a legitimate token, down to a JWE carrying an embedded certificate chain.
 const DefaultMaxTokenBytes = 1 << 18 // 256 KiB.
 
 // ErrTokenTooLarge is returned by Consume when a token exceeds the configured size limit.
@@ -52,8 +51,8 @@ func NewRecipient(config RecipientConfig) *Recipient {
 		config.MaxTokenBytes = DefaultMaxTokenBytes
 	}
 
-	// Resolve the default here rather than lazily in Consume: a Recipient is built once and shared
-	// across goroutines, so writing config on first use would be a data race.
+	// A Recipient is built once and shared across goroutines, so the default is resolved here; a
+	// lazy write from Consume would race.
 	if config.Deserializer == nil {
 		config.Deserializer = json.Unmarshal
 	}
@@ -67,7 +66,7 @@ func NewRecipient(config RecipientConfig) *Recipient {
 // the first that recognizes the token, and fails if none do.
 func (recipient *Recipient) Consume(ctx context.Context, rawToken string, dst any) error {
 	if len(rawToken) > recipient.config.MaxTokenBytes {
-		// Only lengths in the message — never the token itself (a bearer credential).
+		// The token is a bearer credential; the message carries lengths only.
 		return fmt.Errorf(
 			"(Recipient.Consume) %w: %d bytes exceeds limit %d",
 			ErrTokenTooLarge, len(rawToken), recipient.config.MaxTokenBytes,
@@ -92,7 +91,7 @@ func (recipient *Recipient) Consume(ctx context.Context, rawToken string, dst an
 	}
 
 	// A header segment of JSON "null" unmarshals into a nil pointer without error; reject it before
-	// dereferencing rather than panicking on untrusted input.
+	// anything dereferences it.
 	if header == nil {
 		return fmt.Errorf("(Recipient.Consume) %w: null header", ErrUnsupportedTokenFormat)
 	}
@@ -129,17 +128,16 @@ func (recipient *Recipient) Consume(ctx context.Context, rawToken string, dst an
 	return fmt.Errorf("(Recipient.Consume) %w: no compatible plugin found", ErrMismatchRecipientPlugin)
 }
 
-// DecodeUnverified decodes rawToken's claims into dst WITHOUT verifying its signature. The result is
-// therefore untrusted — anyone can forge such a token — so never base a trust decision on it. Use it
-// only to read a token whose authenticity is already established by other means: one just minted
-// locally, or one a separate step has already verified. To verify and decode, use
-// [Recipient.Consume].
+// DecodeUnverified decodes rawToken's claims into dst without verifying its signature. The result is
+// untrusted and must never carry a trust decision. Use it only on a token whose authenticity is
+// already established — one just minted locally, or one a separate step has verified. To verify and
+// decode, use [Recipient.Consume].
 //
 // It reads the payload of a signed (JWS) token; it does not decrypt JWE. The size limit still
 // applies, but no plugin runs and the header's crit list is not enforced.
 func (recipient *Recipient) DecodeUnverified(rawToken string, dst any) error {
 	if len(rawToken) > recipient.config.MaxTokenBytes {
-		// Only lengths in the message — never the token itself (a bearer credential).
+		// The token is a bearer credential; the message carries lengths only.
 		return fmt.Errorf(
 			"(Recipient.DecodeUnverified) %w: %d bytes exceeds limit %d",
 			ErrTokenTooLarge, len(rawToken), recipient.config.MaxTokenBytes,
@@ -151,9 +149,8 @@ func (recipient *Recipient) DecodeUnverified(rawToken string, dst any) error {
 		return fmt.Errorf("(Recipient.DecodeUnverified) decode token: %w", err)
 	}
 
-	// Confirm the input is a structurally valid JWS: the header must be base64url-encoded JSON, not
-	// null or garbage. Signature and crit are deliberately not checked — that is what "unverified"
-	// means — but a non-JWT input should not silently yield claims.
+	// Confirm the input is a structurally valid JWS — the header must be base64url-encoded, non-null
+	// JSON — so a non-JWT input cannot silently yield claims.
 	decodedHeader, err := base64.RawURLEncoding.DecodeString(token.Header)
 	if err != nil {
 		return fmt.Errorf("(Recipient.DecodeUnverified) decode header: %w", err)

--- a/recipient.go
+++ b/recipient.go
@@ -51,8 +51,8 @@ func NewRecipient(config RecipientConfig) *Recipient {
 		config.MaxTokenBytes = DefaultMaxTokenBytes
 	}
 
-	// A Recipient is built once and shared across goroutines, so the default is resolved here; a
-	// lazy write from Consume would race.
+	// A Recipient is built once and shared across goroutines, so defaults are resolved at
+	// construction and never written afterwards.
 	if config.Deserializer == nil {
 		config.Deserializer = json.Unmarshal
 	}

--- a/recipient_test.go
+++ b/recipient_test.go
@@ -82,15 +82,13 @@ func TestRecipient(t *testing.T) {
 
 			config: jwt.RecipientConfig{
 				Plugins: []jwt.RecipientPlugin{
-					// First plugin will return a mismatch error.
 					&fakeRecipientPlugin{payloadErr: jwt.ErrMismatchRecipientPlugin},
-					// Second plugin success!
 					&fakeRecipientPlugin{
 						payload: func(_ *jwa.JWH, _ string) []byte {
 							return []byte(`{"ping":"pong"}`)
 						},
 					},
-					// Third plugin fails, but because previous is successful, it won't be called.
+					// Never reached: the plugin above already consumed the token.
 					&fakeRecipientPlugin{payloadErr: errFoo},
 				},
 			},
@@ -105,9 +103,7 @@ func TestRecipient(t *testing.T) {
 
 			config: jwt.RecipientConfig{
 				Plugins: []jwt.RecipientPlugin{
-					// First plugin will return a mismatch error.
 					&fakeRecipientPlugin{payloadErr: jwt.ErrMismatchRecipientPlugin},
-					// Second plugin fails!
 					&fakeRecipientPlugin{payloadErr: errFoo},
 				},
 			},
@@ -123,10 +119,7 @@ func TestRecipient(t *testing.T) {
 
 			config: jwt.RecipientConfig{
 				Plugins: []jwt.RecipientPlugin{
-					// First plugin will return a mismatch error.
 					&fakeRecipientPlugin{payloadErr: jwt.ErrMismatchRecipientPlugin},
-					// Second plugin also mismatch.
-					// Third plugin fails, but because previous is successful, it won't be called.
 					&fakeRecipientPlugin{payloadErr: jwt.ErrMismatchRecipientPlugin},
 				},
 			},
@@ -169,8 +162,8 @@ func TestRecipientConcurrentConsume(t *testing.T) {
 	token, err := producer.Issue(t.Context(), map[string]any{"foo": "bar"}, nil)
 	require.NoError(t, err)
 
-	// A Recipient with a defaulted deserializer is shared across goroutines. The default must be
-	// resolved at construction, not written on first Consume — the latter races under -race.
+	// A Recipient with a defaulted deserializer is shared across goroutines; the default is resolved
+	// at construction, so nothing writes config here.
 	recipient := jwt.NewRecipient(jwt.RecipientConfig{})
 
 	var wg sync.WaitGroup

--- a/token.go
+++ b/token.go
@@ -22,11 +22,11 @@ type HeaderDecoder struct{}
 
 // Decode implements [TokenDecoder].
 func (decoder *HeaderDecoder) Decode(source string) (string, error) {
-	// SplitN caps the slice regardless of how many separators the input carries, so a token made of
-	// many dots cannot force an unbounded allocation. We only need the first segment, so two suffices.
+	// SplitN caps the slice however many separators the input carries, so a dot-heavy token cannot
+	// force an unbounded allocation. Only the first segment is needed, so two suffices.
 	parts := strings.SplitN(source, ".", 2)
 	if len(parts) < 2 {
-		// The token is an untrusted bearer credential — never embed it in the error, only the shape.
+		// The token is an untrusted bearer credential; the error names the shape only.
 		return "", fmt.Errorf("(HeaderDecoder.Decode) %w: expected at least 2 segments", ErrUnsupportedTokenFormat)
 	}
 
@@ -54,8 +54,8 @@ type RawTokenDecoder struct{}
 
 // Decode implements [TokenDecoder].
 func (decoder *RawTokenDecoder) Decode(source string) (*RawToken, error) {
-	// Limit is segments+1: an over-segmented token still trips the length check below, while the cap
-	// stops a malicious dot-heavy input from allocating an unbounded slice.
+	// Limit is segments+1, so an over-segmented token still trips the length check below while the cap
+	// bounds the allocation a dot-heavy input can force.
 	parts := strings.SplitN(source, ".", 3)
 	if len(parts) != 2 {
 		return nil, fmt.Errorf("(RawTokenDecoder.Decode) %w: expected 2 segments", ErrUnsupportedTokenFormat)
@@ -140,8 +140,8 @@ func (decoder *EncryptedTokenDecoder) Decode(source string) (*EncryptedToken, er
 	}, nil
 }
 
-// DecodeToken runs decoder over source and returns the typed segments. It lets a caller decode a
-// token by passing the matching decoder rather than naming its segment type.
+// DecodeToken runs decoder over source and returns the typed segments, inferring the segment type
+// from the decoder passed in.
 func DecodeToken[R any](source string, decoder TokenDecoder[R]) (R, error) {
 	return decoder.Decode(source)
 }


### PR DESCRIPTION
## Summary

- Comment-only sweep: cut verbosity, replace contrastive framing ("X, not Y") with the positive claim, and drop justification of rejected alternatives in favour of what the code does today.
- 294 comment lines removed, 173 written back. No exported symbol lost its doc comment, and every RFC reference, trust boundary and format description was kept.

## What a reviewer should scrutinise

- **`jwk/rsa.go` is the largest single reduction (-51).** The same six-line block — signature-size arithmetic plus a crypto.stackexchange link — was repeated inside all six RSA signature presets. It now lives once on the `RSAPreset` type doc, which is where the modulus/hash pairing belongs. Worth confirming nothing preset-specific was lost in the merge.
- **`jwk/source.go`** lost the most prose. `RefreshOnUnknownKeyID` and `UnknownKeyIDInterval` kept the two load-bearing facts — the trigger is attacker-controlled, and the cache-age check is the whole rate limit — and shed the surrounding argument.
- **Counter-examples were kept where the wrong path is the one a reader would take**: `jwe/aes_cbc.go`'s MAC-key ordering and `jws/ecdsa.go`'s "not the ASN.1 DER that crypto/ecdsa returns" both stay.
- **Test files lost defect archaeology** — assertions describing bugs that predate the guards now describe what they assert. 25 bare `// OK.` / `// KO.` labels deleted.

## Non-comment changes

Six `KeySize:` lines in `jwk/rsa.go` shift whitespace: removing the comments that were splitting gofmt's alignment groups let it re-align the struct literals. That is the only non-comment hunk in the diff.

## Breaking changes

None. No exported symbol, signature or behaviour changed.

## Test plan

- [x] `gofmt -l .` clean, `go build ./...`, `go vet ./...` pass
- [x] `go tool -modfile=golangci-lint.mod golangci-lint run ./...` — 0 issues
- [x] `go test ./...` green
- [ ] CI green