### PR TITLE
docs: sweep counterfactuals the earlier pass missed

### DIFF
--- a/jwk/serializers/ecdsa.go
+++ b/jwk/serializers/ecdsa.go
@@ -38,7 +38,7 @@ type ECPayload struct {
 // that ecdsa.ParseUncompressedPublicKey expects.
 func pointFromAffine(curve elliptic.Curve, x, y *big.Int) ([]byte, error) {
 	bitSize := curve.Params().BitSize
-	// Reject values that would not get correctly encoded.
+	// Reject values that do not encode correctly.
 	if x.Sign() < 0 || y.Sign() < 0 {
 		return nil, errors.New("negative coordinate")
 	}

--- a/jws/hmac_test.go
+++ b/jws/hmac_test.go
@@ -300,7 +300,7 @@ func TestHMACSourcedVerifier(t *testing.T) {
 func TestSourcedHMACSignerEmptySource(t *testing.T) {
 	t.Parallel()
 
-	// A sourced signer whose source holds no key fails instead of signing with nothing.
+	// A sourced signer whose source holds no key fails.
 	source := testutils.NewStaticKeysSource(t, []*jwk.Key[[]byte]{})
 	producer := jwt.NewProducer(jwt.ProducerConfig{
 		Plugins: []jwt.ProducerPlugin{jws.NewSourcedHMACSigner(source, jws.HS256)},

--- a/jws/rotation_test.go
+++ b/jws/rotation_test.go
@@ -82,7 +82,7 @@ func TestSourcedMixedRotation(t *testing.T) {
 }
 
 // TestSourcedVerifierSurfacesMalformedKey checks that a key of the verifier's own family that fails
-// to decode surfaces as an error, rather than being skipped and masked as an invalid signature.
+// to decode surfaces as an error.
 func TestSourcedVerifierSurfacesMalformedKey(t *testing.T) {
 	t.Parallel()
 

--- a/recipient_plugin.go
+++ b/recipient_plugin.go
@@ -10,7 +10,7 @@ import (
 )
 
 // ErrMismatchRecipientPlugin is returned by a plugin that does not recognize a token, signaling
-// the Recipient to try the next plugin instead of failing.
+// the Recipient to try the next plugin.
 var ErrMismatchRecipientPlugin = errors.New("mismatch recipient plugin")
 
 // A RecipientPlugin validates a token and extracts its raw claims payload. It returns

--- a/testutils/jwk.go
+++ b/testutils/jwk.go
@@ -1,5 +1,5 @@
 // Package testutils provides helpers for exercising the jwt packages in tests,
-// standing in for the live key infrastructure a real deployment would rely on.
+// standing in for the live key infrastructure of a real deployment.
 package testutils
 
 import (


### PR DESCRIPTION
## Summary

Follow-up to the comment sweep. The earlier pass verified itself against its own diff, so comments it chose not to rewrite were never re-checked once the bar tightened to "no counterfactuals, affirmative sentences". This is the tree-wide re-scan.

Five comments rewritten. The conditional is dropped where it defended a design, and kept where it *is* the meaning.

- `jwk/serializers/ecdsa.go` — "Reject values that would not get correctly encoded" → "that do not encode correctly"
- `jws/hmac_test.go`, `jws/rotation_test.go`, `recipient_plugin.go` — trailing "instead of …" / "rather than …" clauses removed; the positive claim already carried the point
- `testutils/jwk.go` — "the live key infrastructure a real deployment would rely on" → "of a real deployment"

## Kept deliberately

`recipient_test.go`'s "a signed token whose signature would never verify" describes the fixture, not a rejected design.

## Breaking changes

None.

## Test plan

- [x] `gofmt -l .` clean, `go build ./...` passes
- [x] `go tool -modfile=golangci-lint.mod golangci-lint run ./...` — 0 issues
- [x] diff contains no non-comment lines
- [ ] CI green