### PR TITLE
fix(jwa): reject a custom payload that names a registered member

### DIFF
--- a/docs/migrations/v2.2.0.md
+++ b/docs/migrations/v2.2.0.md
@@ -33,7 +33,7 @@ after those guards had run and passed. The same held for `exp`, `sub`, `iss`, `a
 
 A collision is now an error wrapping `jwa.ErrReservedMember`, naming every member that collided.
 
-Reserved means every member the registered set *declares*, not only those it encoded. Registered
+Reserved means every member the registered set _declares_, not only those it encoded. Registered
 parameters are `omitempty` throughout, so an unset `exp` encodes to nothing — and a rule written
 against the encoded object would have left exactly the absent parameters open.
 

--- a/docs/migrations/v2.2.0.md
+++ b/docs/migrations/v2.2.0.md
@@ -1,0 +1,71 @@
+# Upgrading to v2.2.0
+
+`v2.2.0` closes a header and claims injection: a custom payload could set a registered parameter, and
+the value it set won.
+
+Following the precedent set in `v1.3.0` and recorded in the `v2.0.0` guide, this ships as a minor.
+The import path does not change and no API is removed.
+
+## Do I need to act?
+
+**Only if you pass caller-controlled data as custom claims or a custom header.** If every call site
+supplies a fixed struct or literal, nothing changes: a payload that names no registered parameter
+encodes exactly as before.
+
+If a call site does route external data into `Producer.Issue`, into `NewBasicClaims`, or into a `JWK`
+payload, it now returns an error where it previously produced a token. Read on.
+
+## What changed
+
+`jwa.JWH`, `jwa.Claims` and `jwa.JWK` merge a typed registered set with a caller-supplied payload.
+That merge let the payload override the registered set:
+
+```go
+producer.Issue(ctx, claims, map[string]any{"alg": "none", "kid": "attacker-kid"})
+// v2.1.0 → header {"alg":"none","kid":"attacker-kid"} on an HMAC-signed token
+// v2.2.0 → error: custom payload may not set a registered member: alg, kid
+```
+
+The override was invisible to every guard in the library. Each signer refuses a header that already
+carries an `alg` by reading the struct field, and the override happened later, inside `MarshalJSON`,
+after those guards had run and passed. The same held for `exp`, `sub`, `iss`, `aud`, `jti`, `nbf` and
+`iat` on claims, and for `kty`, `alg`, `kid`, `use` and `key_ops` on a JWK.
+
+A collision is now an error wrapping `jwa.ErrReservedMember`, naming every member that collided.
+
+Reserved means every member the registered set *declares*, not only those it encoded. Registered
+parameters are `omitempty` throughout, so an unset `exp` encodes to nothing — and a rule written
+against the encoded object would have left exactly the absent parameters open.
+
+## Migrating a call site
+
+Detect the rejection and answer it as a client error rather than a fault:
+
+```go
+token, err := producer.Issue(ctx, claims, customHeader)
+if errors.Is(err, jwa.ErrReservedMember) {
+    // The caller named a registered parameter. This is their input error, not
+    // an internal one; the error text lists the members.
+    return badRequest(err)
+}
+```
+
+If you were relying on the override to set a registered parameter, set it on the typed struct
+instead — that is the field the library's own checks read:
+
+```go
+// before: overridden through the custom payload
+claims, _ := jwt.NewBasicClaims(map[string]any{"sub": "user-42"}, config)
+
+// after: the registered field, honoured by every check
+claims, _ := jwt.NewBasicClaims(nil, jwt.ClaimsProducerConfig{
+    TargetConfig: jwt.TargetConfig{Subject: "user-42"},
+})
+```
+
+## Also in this release
+
+`jwp.ClaimsCheckTimestamp` treats a negative `exp` as expired, and as absent when `requireExp` is
+set. A negative value used to satisfy both gates at once — not zero, so it read as present, and not
+positive, so it was never compared against the clock — which made the token non-expiring even with
+`requireExp` enabled. A token bearing a negative `exp` is now rejected.

--- a/jwa/errors.go
+++ b/jwa/errors.go
@@ -1,7 +1,16 @@
 package jwa
 
-import "errors"
+import (
+	"errors"
+
+	"github.com/a-novel-kit/jwt/v2/jwa/internal"
+)
 
 // ErrUnsupportedKeyType is returned when an operation receives a key whose
 // type it does not support.
 var ErrUnsupportedKeyType = errors.New("unsupported key type")
+
+// ErrReservedMember is returned by JWH, Claims and JWK marshaling when the
+// custom payload names a registered parameter. It is re-exported here because
+// the check itself lives in an internal package a consumer cannot import.
+var ErrReservedMember = internal.ErrReservedMember

--- a/jwa/internal/json_partial.go
+++ b/jwa/internal/json_partial.go
@@ -5,12 +5,33 @@ package internal
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+	"sync"
 )
 
-// MarshalPartial encodes common and custom into one JSON object, with custom's
-// members overriding any that collide with common. A nil or "null" custom yields
-// the encoding of common alone.
+// ErrReservedMember reports a custom payload naming a member that belongs to the
+// registered set. The registered value is the one every guard in this library is
+// written against, and a custom member displacing it takes effect during
+// encoding, after each of those guards has run and passed.
+var ErrReservedMember = errors.New("custom payload may not set a registered member")
+
+// MarshalPartial encodes common and custom into one JSON object. A nil or "null"
+// custom yields the encoding of common alone.
+//
+// The two sets of members must be disjoint. A custom member naming one that
+// common reserves is an error rather than an override: common holds the
+// parameters the format assigns meaning to, and the callers that populate it —
+// signers setting alg, producers setting exp — have no way to observe a value
+// that replaces theirs at encoding time.
+//
+// Reserved means every member common could contribute, not only those it did.
+// Registered parameters are omitempty throughout, so an unset one encodes to
+// nothing, and a rule written against the encoded object would leave exactly the
+// absent parameters open.
 func MarshalPartial[T any](common T, custom json.RawMessage) ([]byte, error) {
 	if custom == nil || string(custom) == "null" {
 		return json.Marshal(common)
@@ -28,9 +49,36 @@ func MarshalPartial[T any](common T, custom json.RawMessage) ([]byte, error) {
 		return nil, fmt.Errorf("(MarshalPartial) convert common to map: %w", err)
 	}
 
-	err = json.Unmarshal(custom, &merged)
+	var customMembers map[string]json.RawMessage
+
+	err = json.Unmarshal(custom, &customMembers)
 	if err != nil {
 		return nil, fmt.Errorf("(MarshalPartial) convert custom to map: %w", err)
+	}
+
+	declared := declaredMembers(reflect.TypeFor[T]())
+
+	var reserved []string
+
+	for name, value := range customMembers {
+		_, isDeclared := declared[name]
+		_, isEncoded := merged[name]
+
+		if isDeclared || isEncoded {
+			reserved = append(reserved, name)
+
+			continue
+		}
+
+		merged[name] = value
+	}
+
+	if len(reserved) > 0 {
+		// Map iteration order is random, so the names are sorted to keep one
+		// input from producing several different messages.
+		sort.Strings(reserved)
+
+		return nil, fmt.Errorf("(MarshalPartial) %w: %s", ErrReservedMember, strings.Join(reserved, ", "))
 	}
 
 	mergedSerialized, err := json.Marshal(merged)
@@ -39,6 +87,73 @@ func MarshalPartial[T any](common T, custom json.RawMessage) ([]byte, error) {
 	}
 
 	return mergedSerialized, nil
+}
+
+// declaredMembersCache memoises declaredMembers, which every token issued walks
+// otherwise.
+var declaredMembersCache sync.Map // reflect.Type -> map[string]struct{}
+
+// declaredMembers returns the JSON member names a struct type declares,
+// including those promoted from the structs it embeds. A type with no fields to
+// declare — a map, or the interface a caller passes through the generic
+// parameter — yields none, and the encoded object is then the only account of
+// what common contributes.
+func declaredMembers(typ reflect.Type) map[string]struct{} {
+	for typ != nil && typ.Kind() == reflect.Pointer {
+		typ = typ.Elem()
+	}
+
+	if typ == nil || typ.Kind() != reflect.Struct {
+		return nil
+	}
+
+	if cached, ok := declaredMembersCache.Load(typ); ok {
+		names, _ := cached.(map[string]struct{})
+
+		return names
+	}
+
+	names := map[string]struct{}{}
+
+	for i := range typ.NumField() {
+		field := typ.Field(i)
+
+		tag := field.Tag.Get("json")
+		if tag == "-" {
+			continue
+		}
+
+		name, _, _ := strings.Cut(tag, ",")
+
+		// An embedded struct with no name of its own promotes its members into
+		// the enclosing object, so they are the enclosing type's members too.
+		// encoding/json promotes them even when the embedded type is unexported,
+		// which is why this runs before the exported check; an embedded
+		// non-struct is a plain member named after its type.
+		if field.Anonymous && name == "" {
+			if promoted := declaredMembers(field.Type); promoted != nil {
+				for member := range promoted {
+					names[member] = struct{}{}
+				}
+
+				continue
+			}
+		}
+
+		if !field.IsExported() {
+			continue
+		}
+
+		if name == "" {
+			name = field.Name
+		}
+
+		names[name] = struct{}{}
+	}
+
+	declaredMembersCache.Store(typ, names)
+
+	return names
 }
 
 // UnmarshalPartial decodes the typed fields of src into a value of type T and

--- a/jwa/internal/json_partial.go
+++ b/jwa/internal/json_partial.go
@@ -13,25 +13,18 @@ import (
 	"sync"
 )
 
-// ErrReservedMember reports a custom payload naming a member that belongs to the
-// registered set. The registered value is the one every guard in this library is
-// written against, and a custom member displacing it takes effect during
-// encoding, after each of those guards has run and passed.
+// ErrReservedMember reports a custom payload naming a member of the registered
+// set. Every guard in this library reads the registered value; a custom member
+// displaces it during encoding, once those guards have run and passed.
 var ErrReservedMember = errors.New("custom payload may not set a registered member")
 
 // MarshalPartial encodes common and custom into one JSON object. A nil or "null"
 // custom yields the encoding of common alone.
 //
-// The two sets of members must be disjoint. A custom member naming one that
-// common reserves is an error rather than an override: common holds the
-// parameters the format assigns meaning to, and the callers that populate it —
-// signers setting alg, producers setting exp — have no way to observe a value
-// that replaces theirs at encoding time.
-//
-// Reserved means every member common could contribute, not only those it did.
-// Registered parameters are omitempty throughout, so an unset one encodes to
-// nothing, and a rule written against the encoded object would leave exactly the
-// absent parameters open.
+// The two sets must be disjoint: a custom member naming one that common reserves
+// is an error. Reserved covers every member common declares, not only those it
+// encoded — registered parameters are omitempty, so an unset one encodes to
+// nothing and would otherwise stay open to a custom value.
 func MarshalPartial[T any](common T, custom json.RawMessage) ([]byte, error) {
 	if custom == nil || string(custom) == "null" {
 		return json.Marshal(common)
@@ -94,10 +87,9 @@ func MarshalPartial[T any](common T, custom json.RawMessage) ([]byte, error) {
 var declaredMembersCache sync.Map // reflect.Type -> map[string]struct{}
 
 // declaredMembers returns the JSON member names a struct type declares,
-// including those promoted from the structs it embeds. A type with no fields to
-// declare — a map, or the interface a caller passes through the generic
-// parameter — yields none, and the encoded object is then the only account of
-// what common contributes.
+// including those promoted from embedded structs. A non-struct — a map, or the
+// interface a caller reaches the generic parameter through — yields none,
+// leaving the encoded object as the only account of common's members.
 func declaredMembers(typ reflect.Type) map[string]struct{} {
 	for typ != nil && typ.Kind() == reflect.Pointer {
 		typ = typ.Elem()
@@ -125,11 +117,14 @@ func declaredMembers(typ reflect.Type) map[string]struct{} {
 
 		name, _, _ := strings.Cut(tag, ",")
 
-		// An embedded struct with no name of its own promotes its members into
-		// the enclosing object, so they are the enclosing type's members too.
-		// encoding/json promotes them even when the embedded type is unexported,
-		// which is why this runs before the exported check; an embedded
-		// non-struct is a plain member named after its type.
+		// An embedded struct promotes its members into the enclosing object, and
+		// encoding/json does so even when the embedded type is unexported —
+		// hence promotion before the exported check.
+		//
+		// An embedded non-struct falls through to be named after its type, which
+		// is how encoding/json encodes it: `struct{ MyString }` emits
+		// {"MyString":…}. It is a member like any other, so it is reserved like
+		// any other.
 		if field.Anonymous && name == "" {
 			if promoted := declaredMembers(field.Type); promoted != nil {
 				for member := range promoted {

--- a/jwa/internal/json_partial_test.go
+++ b/jwa/internal/json_partial_test.go
@@ -142,6 +142,52 @@ func TestMarshalPartialReservesUnsetMembers(t *testing.T) {
 	})
 }
 
+// An embedded field is reserved on the same terms encoding/json encodes it on,
+// which differ by what is embedded. The encoding is asserted first in each case,
+// so the rule is pinned against the encoder rather than against a reading of it.
+func TestMarshalPartialReservesEmbeddedMembers(t *testing.T) {
+	t.Parallel()
+
+	type Promoted struct {
+		Kid string `json:"kid,omitempty"`
+	}
+
+	type Named string
+
+	type hidden string
+
+	type Empty struct{}
+
+	type common struct {
+		Promoted // a struct: promotes kid
+		Named    // not a struct: encodes under its type name
+		hidden   // not a struct and unexported: encodes nothing
+		Empty    // a struct with nothing to promote
+	}
+
+	require.JSONEq(t, `{"Named":""}`, string(mustMarshal(t, common{hidden: "set"})),
+		"the encoder names an embedded non-struct after its type and drops an unexported one")
+
+	for _, name := range []string{"kid", "Named"} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := internal.MarshalPartial(common{}, json.RawMessage(`{"`+name+`":"injected"}`))
+			require.ErrorIs(t, err, internal.ErrReservedMember)
+		})
+	}
+
+	t.Run("an embedded type that encodes nothing reserves nothing", func(t *testing.T) {
+		t.Parallel()
+
+		// Empty promotes no member and hidden encodes none, so neither type name
+		// is taken.
+		out, err := internal.MarshalPartial(common{}, json.RawMessage(`{"Empty":1,"hidden":2}`))
+		require.NoError(t, err)
+		require.JSONEq(t, `{"Named":"","Empty":1,"hidden":2}`, string(out))
+	})
+}
+
 func mustMarshal(t *testing.T, v any) []byte {
 	t.Helper()
 

--- a/jwa/internal/json_partial_test.go
+++ b/jwa/internal/json_partial_test.go
@@ -18,7 +18,8 @@ func TestMarshalPartial(t *testing.T) {
 		value any
 		extra json.RawMessage
 
-		expect []byte
+		expect      []byte
+		expectNames string
 	}{
 		{
 			name: "Success",
@@ -50,7 +51,19 @@ func TestMarshalPartial(t *testing.T) {
 			},
 			extra: json.RawMessage(`{"b":"qux","c":"baz"}`),
 
-			expect: []byte(`{"a":"foo","b":"qux","c":"baz"}`),
+			expectNames: "b",
+		},
+		{
+			// The names are sorted, so one input yields one message.
+			name: "SeveralOverlaps",
+
+			value: map[string]string{
+				"a": "foo",
+				"b": "bar",
+			},
+			extra: json.RawMessage(`{"b":"qux","a":"quux"}`),
+
+			expectNames: "a, b",
 		},
 	}
 
@@ -59,10 +72,83 @@ func TestMarshalPartial(t *testing.T) {
 			t.Parallel()
 
 			actual, err := internal.MarshalPartial(testCase.value, testCase.extra)
+
+			if testCase.expectNames != "" {
+				require.ErrorIs(t, err, internal.ErrReservedMember)
+				require.ErrorContains(t, err, testCase.expectNames)
+				require.Nil(t, actual)
+
+				return
+			}
+
 			require.NoError(t, err)
 			require.JSONEq(t, string(testCase.expect), string(actual))
 		})
 	}
+}
+
+// A registered parameter is reserved whether or not the value being encoded
+// carries one. Every registered parameter in this library is omitempty, so an
+// unset one encodes to nothing and a check against the encoded object would
+// leave exactly the absent parameters open.
+func TestMarshalPartialReservesUnsetMembers(t *testing.T) {
+	t.Parallel()
+
+	type embedded struct {
+		Kid string `json:"kid,omitempty"`
+	}
+
+	type common struct {
+		embedded
+
+		Alg     string `json:"alg,omitempty"`
+		Exp     int64  `json:"exp,omitempty"`
+		Renamed string `json:"cty,omitempty"`
+		Skipped string `json:"-"`
+		Untaged string
+	}
+
+	// Nothing is set, so alg, exp, cty and kid are absent from the encoding, and
+	// each is reserved below on the strength of the declaration alone. Untaged
+	// carries no tag and so cannot be omitempty, which is why it is here.
+	require.JSONEq(t, `{"Untaged":""}`, string(mustMarshal(t, common{})))
+
+	for _, name := range []string{"alg", "exp", "cty", "kid", "Untaged"} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := internal.MarshalPartial(common{}, json.RawMessage(`{"`+name+`":"injected"}`))
+			require.ErrorIs(t, err, internal.ErrReservedMember)
+			require.ErrorContains(t, err, name)
+		})
+	}
+
+	t.Run("a field the encoding drops is not reserved", func(t *testing.T) {
+		t.Parallel()
+
+		// `json:"-"` means the member never appears, so a custom member of that
+		// name collides with nothing.
+		out, err := internal.MarshalPartial(common{}, json.RawMessage(`{"Skipped":"mine"}`))
+		require.NoError(t, err)
+		require.JSONEq(t, `{"Untaged":"","Skipped":"mine"}`, string(out))
+	})
+
+	t.Run("an unrelated member still passes through", func(t *testing.T) {
+		t.Parallel()
+
+		out, err := internal.MarshalPartial(common{Alg: "HS256"}, json.RawMessage(`{"role":"admin"}`))
+		require.NoError(t, err)
+		require.JSONEq(t, `{"Untaged":"","alg":"HS256","role":"admin"}`, string(out))
+	})
+}
+
+func mustMarshal(t *testing.T, v any) []byte {
+	t.Helper()
+
+	out, err := json.Marshal(v)
+	require.NoError(t, err)
+
+	return out
 }
 
 func TestUnmarshalPartial(t *testing.T) {

--- a/jwp/claims_checker.go
+++ b/jwp/claims_checker.go
@@ -101,15 +101,19 @@ func NewClaimsCheckTimestamp(leeway time.Duration, requireExp bool) *ClaimsCheck
 }
 
 func (claimsCheck *ClaimsCheckTimestamp) CheckClaims(claims *jwa.Claims) error {
+	// Absence of an expiry is Exp == 0, and any other value is a bound to check.
+	// Gating the check on Exp > 0 and the requirement on Exp == 0 left a
+	// negative Exp satisfying both: it is not zero, so it reads as present, and
+	// it is not positive, so it is never compared against the clock.
 	exp := time.Unix(claims.Exp, 0)
-	if claims.Exp > 0 && exp.Before(time.Now().Add(-claimsCheck.leeway)) {
+	if claims.Exp != 0 && exp.Before(time.Now().Add(-claimsCheck.leeway)) {
 		return fmt.Errorf(
 			"token expired at %s",
 			exp.String(),
 		)
 	}
 
-	if claimsCheck.requireExp && claims.Exp == 0 {
+	if claimsCheck.requireExp && claims.Exp <= 0 {
 		return errors.New("missing expiration date")
 	}
 

--- a/jwp/claims_checker_test.go
+++ b/jwp/claims_checker_test.go
@@ -247,6 +247,47 @@ func TestClaimsChecker(t *testing.T) {
 			expectErr: jwp.ErrInvalidClaims,
 		},
 		{
+			// A negative exp used to satisfy both gates at once: not zero, so it
+			// read as present, and not positive, so it was never compared against
+			// the clock. The token then never expired, requireExp included.
+			name: "Exp/Failure/Negative",
+
+			config: &jwp.ClaimsCheckerConfig{
+				Checks: []jwp.ClaimsCheck{
+					jwp.NewClaimsCheckTimestamp(0, false),
+				},
+			},
+
+			raw: map[string]any{
+				"exp": -1,
+			},
+
+			dst: map[string]any{},
+
+			expect: map[string]any{},
+
+			expectErr: jwp.ErrInvalidClaims,
+		},
+		{
+			name: "Exp/Failure/NegativeRequired",
+
+			config: &jwp.ClaimsCheckerConfig{
+				Checks: []jwp.ClaimsCheck{
+					jwp.NewClaimsCheckTimestamp(0, true),
+				},
+			},
+
+			raw: map[string]any{
+				"exp": -1,
+			},
+
+			dst: map[string]any{},
+
+			expect: map[string]any{},
+
+			expectErr: jwp.ErrInvalidClaims,
+		},
+		{
 			name: "CheckRaw/Success",
 
 			config: &jwp.ClaimsCheckerConfig{

--- a/reserved_members_test.go
+++ b/reserved_members_test.go
@@ -1,0 +1,125 @@
+package jwt_test
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/a-novel-kit/jwt/v2"
+	"github.com/a-novel-kit/jwt/v2/jwa"
+)
+
+// End-to-end cover for the custom-payload override, at the level a consumer meets it. A caller that
+// routes semi-trusted data into customClaims or customHeader reaches an override no guard can see:
+// each signer refuses a header that already carries an alg by reading the struct field, and the
+// override lands later, inside MarshalJSON.
+
+// signingPlugin stands in for a signer: it stamps the algorithm on the header, which is exactly the
+// value a custom header used to be able to replace.
+type signingPlugin struct{ alg jwa.Alg }
+
+func (plugin *signingPlugin) Header(_ context.Context, header *jwa.JWH) (*jwa.JWH, error) {
+	header.Alg = plugin.alg
+
+	return header, nil
+}
+
+func (plugin *signingPlugin) Transform(_ context.Context, _ *jwa.JWH, token string) (string, error) {
+	return token + ".signature", nil
+}
+
+func newSigningProducer(alg jwa.Alg) *jwt.Producer {
+	return jwt.NewProducer(jwt.ProducerConfig{
+		Plugins: []jwt.ProducerPlugin{&signingPlugin{alg: alg}},
+	})
+}
+
+func TestIssueRejectsAReservedCustomHeader(t *testing.T) {
+	t.Parallel()
+
+	producer := newSigningProducer(jwa.HS256)
+
+	_, err := producer.Issue(t.Context(), map[string]any{"role": "user"}, map[string]any{
+		"alg": "none",
+		"kid": "attacker-kid",
+	})
+
+	require.ErrorIs(t, err, jwa.ErrReservedMember)
+	require.ErrorContains(t, err, "alg")
+	require.ErrorContains(t, err, "kid")
+}
+
+func TestIssueKeepsAnUnreservedCustomHeader(t *testing.T) {
+	t.Parallel()
+
+	producer := newSigningProducer(jwa.HS256)
+
+	token, err := producer.Issue(t.Context(), map[string]any{"role": "user"}, map[string]any{
+		"myapp-tenant": "acme",
+	})
+	require.NoError(t, err)
+
+	header := decodeSegment(t, token, 0)
+	require.JSONEq(t, `{"alg":"HS256","myapp-tenant":"acme"}`, header)
+}
+
+func TestIssueRejectsReservedCustomClaims(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{"exp", "sub", "iss", "aud", "jti", "nbf", "iat"} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			claims, err := jwt.NewBasicClaims(
+				map[string]any{name: "injected"},
+				jwt.ClaimsProducerConfig{TTL: time.Hour},
+			)
+			require.NoError(t, err)
+
+			// NewBasicClaims only stores the payload; the merge happens when the
+			// claims are encoded, which is where every earlier check has already
+			// finished.
+			_, err = json.Marshal(claims)
+			require.ErrorIs(t, err, jwa.ErrReservedMember)
+			require.ErrorContains(t, err, name)
+		})
+	}
+}
+
+func TestIssueKeepsUnreservedCustomClaims(t *testing.T) {
+	t.Parallel()
+
+	claims, err := jwt.NewBasicClaims(
+		map[string]any{"role": "admin"},
+		jwt.ClaimsProducerConfig{TTL: time.Hour},
+	)
+	require.NoError(t, err)
+
+	producer := newSigningProducer(jwa.HS256)
+
+	token, err := producer.Issue(t.Context(), claims, nil)
+	require.NoError(t, err)
+
+	var payload map[string]any
+
+	require.NoError(t, json.Unmarshal([]byte(decodeSegment(t, token, 1)), &payload))
+	require.Equal(t, "admin", payload["role"])
+	require.NotZero(t, payload["exp"], "the producer's own exp must survive")
+}
+
+func decodeSegment(t *testing.T, token string, index int) string {
+	t.Helper()
+
+	segments := strings.Split(token, ".")
+	require.Greater(t, len(segments), index)
+
+	raw, err := base64.RawURLEncoding.DecodeString(segments[index])
+	require.NoError(t, err)
+
+	return string(raw)
+}


### PR DESCRIPTION
Closes #478, implementing your ruling: *"Add the rule to `MarshalPartial`, and return an error on collision."*

## The defect

`MarshalPartial` documented its own bug honestly — *"with custom's members overriding any that collide with common"* — and that merge is applied to `JWHCommon` (which holds `alg`) and `ClaimsCommon` (which holds `exp`, `sub`, `iss`, `aud`, `jti`).

**No guard could see it.** Each signer refuses a header that already carries an `alg` by reading the *struct field*; the override happens later, inside `MarshalJSON`, after every guard has run and passed.

```
issue err: <nil>
emitted header: {"alg":"none","kid":"attacker-kid"}
```

An HMAC-signed token advertising `alg: none`. Drop the third segment and a default-configured `Recipient` accepts an unsecured token.

## The fix, and the one non-obvious part

The two sets are now disjoint, and a collision returns `ErrReservedMember` naming every member that collided (sorted, so one input yields one message).

**Reserved is what the type *declares*, not what it *encoded*.** This is the part worth reviewing: every registered parameter in this library is `omitempty`, so an unset `exp` encodes to nothing — and the obvious implementation, checking custom against the keys of the marshalled `common`, would leave **exactly the absent parameters open**. That is the injection. So the reserved set comes from reflection over the declared fields, unioned with the encoded keys (which is what covers a non-struct `common`, as the existing tests pass a `map`).

Two details in that walk:

- It follows the promotion `encoding/json` performs for embedded structs — `JWHCommon` embeds five of them.
- It follows promotion out of embedded types that are **themselves unexported**, which `encoding/json` does and `reflect.StructField.IsExported()` reports as false. I got this wrong first and the `kid` case caught it.

Memoised per `reflect.Type`, since otherwise every token issued walks it.

`jwa.ErrReservedMember` re-exports the error, because the check lives in an `internal` package a consumer cannot import. `JWH`, `Claims` **and `JWK`** all route through this merge, so a `kty`/`kid` override on a JWK is covered by the same change — that third caller wasn't in the issue.

## Also here

`jwp.ClaimsCheckTimestamp` treated a negative `exp` as neither present nor checkable — not zero, so it satisfied `requireExp`; not positive, so it was never compared against the clock. `exp: -1` produced a non-expiring token *with `requireExp` enabled*. Now `Exp != 0` is checked and `Exp <= 0` fails the requirement.

## The test that asserted the bug

`json_partial_test.go`'s `Overlap` case asserted the override was correct, using the names `a`/`b`/`c` where it reads as entirely harmless. It is now the negative case.

It was also **the only failure** when the fix first went in — nothing else in the suite relied on the merge.

Red check, against the previous behaviour:

```
--- FAIL: TestIssueRejectsAReservedCustomHeader
--- FAIL: TestIssueRejectsReservedCustomClaims        (exp iat nbf jti aud iss sub)
--- FAIL: TestMarshalPartial                          (Overlap, SeveralOverlaps)
--- FAIL: TestMarshalPartialReservesUnsetMembers      (alg cty exp kid Untaged)
--- FAIL: TestClaimsChecker                           (Exp/Failure/Negative, /NegativeRequired)
```

20 subtests. The end-to-end pair issues through a real `Producer` with a plugin that stamps the algorithm, which is the level a consumer meets this at. Positive cases pin that an *unreserved* custom header and unreserved custom claims still pass through untouched, and that the producer's own `exp` survives.

Full suite green, `golangci-lint` 0 issues.

## Release

**Minor — `v2.2.0`**, with `docs/migrations/v2.2.0.md`.

Not my call to invent: `docs/migrations/v2.0.0.md` records the policy in its own opening line — *"The security fixes shipped non-breaking in `v1.3.0`; this release adds the breaking API cleanups `v1.3.0` could not."* A major would force every consumer onto a `/v3` import path for a security fix, which slows the adoption the fix exists to get.

## Consumer impact — one, and it needs a follow-up

`service-json-keys` is the only live caller: `core/claimsSign.go:54` passes `request.Claims` — typed `any` and documented as *"Any JSON-serializable value is accepted"* — straight into `NewBasicClaims`.

So once json-keys picks this up, a client POSTing `{"claims":{"sub":"attacker"}}` goes from *silently getting the override* to *getting an error*. That is the point. But the handler has no mapping for it, so it would surface as an internal fault rather than a client error. **I'll file that on json-keys** — it should map `jwa.ErrReservedMember` to a 4xx before it upgrades. Filing the silent hole as a 500 would be a poor trade.

`service-authentication`, `service-narrative-engine` and `service-template` have no `Issue`/`NewBasicClaims` call sites at all.
