### PR TITLE
fix(jwa): strip registered members from the payload UnmarshalPartial returns

### DIFF
--- a/jwa/internal/json_partial.go
+++ b/jwa/internal/json_partial.go
@@ -152,8 +152,14 @@ func declaredMembers(typ reflect.Type) map[string]struct{} {
 }
 
 // UnmarshalPartial decodes the typed fields of src into a value of type T and
-// returns src unchanged alongside it, so the caller can later decode its own
-// custom fields from the same bytes.
+// returns the members left over, so the caller can decode its own custom fields
+// from them.
+//
+// The members T declares are removed from that remainder, which makes this the
+// inverse of MarshalPartial: what the typed value carries comes back out of the
+// typed value, and re-encoding the pair reproduces src. Returning src whole
+// would put every registered member in the custom half, and encoding it again
+// would be rejected as an override of the value it was read from.
 func UnmarshalPartial[T any](src []byte) (T, json.RawMessage, error) {
 	var common T
 
@@ -162,5 +168,26 @@ func UnmarshalPartial[T any](src []byte) (T, json.RawMessage, error) {
 		return common, nil, fmt.Errorf("(UnmarshalPartial) unmarshal common: %w", err)
 	}
 
-	return common, src, nil
+	declared := declaredMembers(reflect.TypeFor[T]())
+	if len(declared) == 0 {
+		return common, src, nil
+	}
+
+	var members map[string]json.RawMessage
+
+	err = json.Unmarshal(src, &members)
+	if err != nil {
+		return common, nil, fmt.Errorf("(UnmarshalPartial) convert source to map: %w", err)
+	}
+
+	for name := range declared {
+		delete(members, name)
+	}
+
+	custom, err := json.Marshal(members)
+	if err != nil {
+		return common, nil, fmt.Errorf("(UnmarshalPartial) serialize custom: %w", err)
+	}
+
+	return common, custom, nil
 }

--- a/jwa/internal/json_partial_test.go
+++ b/jwa/internal/json_partial_test.go
@@ -214,6 +214,9 @@ func TestUnmarshalPartial(t *testing.T) {
 		extra  json.RawMessage
 	}{
 		{
+			// The typed fields come back in the value, and only the rest comes
+			// back as custom — so re-encoding the pair does not re-supply a and b
+			// as overrides of themselves.
 			name: "Success",
 
 			src: []byte(`{"a":"foo","b":"bar","c":"baz"}`),
@@ -222,7 +225,18 @@ func TestUnmarshalPartial(t *testing.T) {
 				A: "foo",
 				B: "bar",
 			},
-			extra: json.RawMessage(`{"a":"foo","b":"bar","c":"baz"}`),
+			extra: json.RawMessage(`{"c":"baz"}`),
+		},
+		{
+			name: "NoCustomMembers",
+
+			src: []byte(`{"a":"foo","b":"bar"}`),
+
+			expect: partialType{
+				A: "foo",
+				B: "bar",
+			},
+			extra: json.RawMessage(`{}`),
 		},
 	}
 
@@ -234,6 +248,54 @@ func TestUnmarshalPartial(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, testCase.expect, actual)
 			require.JSONEq(t, string(testCase.extra), string(extra))
+		})
+	}
+}
+
+// The pair has to compose: decoding an object and encoding the result back must
+// reproduce it. Without this, every registered member lands in the custom half
+// on the way in and is rejected as an override on the way out.
+func TestPartialRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	type common struct {
+		Kty string `json:"kty,omitempty"`
+		Kid string `json:"kid,omitempty"`
+		Alg string `json:"alg,omitempty"`
+	}
+
+	testCases := []struct {
+		name string
+		src  string
+	}{
+		{
+			name: "registered and custom members",
+			src:  `{"kty":"EC","kid":"k1","alg":"ES256","x":"abc","crv":"P-256"}`,
+		},
+		{
+			name: "registered members only",
+			src:  `{"kty":"oct","kid":"k1"}`,
+		},
+		{
+			name: "custom members only",
+			src:  `{"x":"abc","crv":"P-256"}`,
+		},
+		{
+			name: "no members at all",
+			src:  `{}`,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			decoded, custom, err := internal.UnmarshalPartial[common]([]byte(testCase.src))
+			require.NoError(t, err)
+
+			encoded, err := internal.MarshalPartial(decoded, custom)
+			require.NoError(t, err)
+			require.JSONEq(t, testCase.src, string(encoded))
 		})
 	}
 }


### PR DESCRIPTION
🚨 **Regression in v2.2.0, which I shipped in #494.** Recommend `v2.2.1` promptly.

## What breaks

`UnmarshalPartial` returns the source object **whole** as the custom payload. After #494 made a custom member naming a registered one an error, that means every decode puts the registered members in the custom half — and encoding the value again is rejected as an override of the value it was just read from.

Reproduced standalone against released `v2.2.0`:

```go
var key jwa.JWK
json.Unmarshal([]byte(`{"kty":"EC","kid":"k1","alg":"ES256","x":"abc","y":"def","crv":"P-256"}`), &key)
// Payload after unmarshal: {"kty":"EC","kid":"k1","alg":"ES256","x":"abc","y":"def","crv":"P-256"}

json.Marshal(&key)
// err: json: error calling MarshalJSON for type *jwa.JWK:
//      (MarshalPartial) custom payload may not set a registered member: alg, kid, kty
```

**Any decode-then-encode of a `JWK`, `JWH` or `Claims` fails.** `service-json-keys` serves its public keys that way, so v2.2.0 takes its JWK endpoints down — `TestJwkExtract` is what caught it, on the bump PR.

## The fix

`UnmarshalPartial` now removes the members `T` declares from the payload it returns, making the two functions **inverses**: what the typed value carries comes back out of the typed value, and re-encoding the pair reproduces the source.

It reuses the same `declaredMembers` walk `MarshalPartial` uses, so the set removed on the way in is exactly the set refused on the way out — they cannot drift.

The security property is unchanged, and arguably firmer: `Payload` now structurally cannot hold a registered member, rather than holding one that a value check would have to forgive.

## Blast radius of the change itself

`UnmarshalPartial`'s contract moves from "returns src unchanged" to "returns the leftover members". The library's own readers of `.Payload` are the key serializers — `jwk/rsa.go`, `jwk/ed25519.go`, `jwk/ecdh.go`, `jwk/aes.go`, `jwk/hmac.go`, `jwe/jwek/key_derivation_ecdh_kw.go` — and they decode `x`, `y`, `n`, `e`, `d`, `k`, `crv`. All custom members, unaffected either way.

## Verification

- Full suite: **11 packages ok**. The only test that needed changing was `TestUnmarshalPartial/Success`, which asserted the old "src unchanged" shape.
- **`TestPartialRoundTrip`** is the test whose absence let v2.2.0 ship: it covers registered+custom together, registered alone, custom alone, and neither, asserting `Marshal(Unmarshal(src)) == src`.
- Against the real failure: `service-json-keys` with a local `replace` on this branch — `internal/core` goes from 3 failing `TestJwkExtract` subtests to **fully green**.

## Sequencing

1. Merge + tag **v2.2.1**.
2. `service-json-keys` bumps to v2.2.1 (not v2.2.0) together with the error classification in a-novel/service-json-keys#860.

No other repo depends on `jwt`, so the exposure is limited to json-keys, and its bump has not landed.

## What I should have caught

#494 reasoned carefully about which members are reserved and not at all about **who supplies the custom payload**. `UnmarshalPartial` is the library's own supplier, and it hands over a payload that its counterpart then refuses. A round-trip test is the obvious guard for a Marshal/Unmarshal pair and the suite had none — so the pair was never exercised as a pair.
