### PR TITLE
fix(jwp): refuse to embed a key that carries private material

### DIFF
--- a/jwk/public.go
+++ b/jwk/public.go
@@ -1,0 +1,111 @@
+package jwk
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/a-novel-kit/jwt/v2/jwa"
+)
+
+// ErrPrivateKeyMaterial reports a key carrying members that must not leave the
+// signer: the RSA private exponent and its CRT factors, the EC and OKP private
+// scalar, or the octet sequence a symmetric key consists of.
+var ErrPrivateKeyMaterial = errors.New("key carries private material")
+
+// privateMembers are the JWK members RFC 7518 §6 defines as private, across
+// every key type. RSA carries the most; EC and OKP carry only "d"; a symmetric
+// key is nothing but its secret, which is why Public refuses one outright.
+//
+// The names are a closed set fixed by the RFC, so a new key type is the only
+// thing that can add to it.
+//
+// https://datatracker.ietf.org/doc/html/rfc7518#section-6
+var privateMembers = []string{
+	"d",   // RSA private exponent; EC and OKP private scalar
+	"p",   // RSA first prime factor
+	"q",   // RSA second prime factor
+	"dp",  // RSA first factor CRT exponent
+	"dq",  // RSA second factor CRT exponent
+	"qi",  // RSA first CRT coefficient
+	"oth", // RSA other primes, each with its own r, d and t
+	"k",   // symmetric key value
+}
+
+// HasPrivateMaterial reports whether key carries any member that must stay with
+// the signer. A symmetric key always does.
+func HasPrivateMaterial(key *jwa.JWK) (bool, error) {
+	if key == nil {
+		return false, nil
+	}
+
+	if key.KTY == jwa.KTYOct {
+		return true, nil
+	}
+
+	members, err := payloadMembers(key)
+	if err != nil {
+		return false, err
+	}
+
+	for _, name := range privateMembers {
+		if _, ok := members[name]; ok {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// Public returns key with every private member removed, leaving the half a
+// recipient needs to verify. The original is not modified.
+//
+// A symmetric key has no public half — its single member is the secret — so one
+// yields ErrPrivateKeyMaterial rather than an emptied key that would look
+// publishable.
+func Public(key *jwa.JWK) (*jwa.JWK, error) {
+	if key == nil {
+		return nil, nil
+	}
+
+	if key.KTY == jwa.KTYOct {
+		return nil, fmt.Errorf("%w: a %s key is its secret and has no public half", ErrPrivateKeyMaterial, key.KTY)
+	}
+
+	members, err := payloadMembers(key)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, name := range privateMembers {
+		delete(members, name)
+	}
+
+	payload, err := json.Marshal(members)
+	if err != nil {
+		return nil, fmt.Errorf("(Public) serialize payload: %w", err)
+	}
+
+	out := *key
+	out.Payload = payload
+
+	return &out, nil
+}
+
+// payloadMembers decodes a key's type-specific members. An absent payload
+// decodes to an empty set, so a key holding only common parameters is read as
+// carrying nothing private.
+func payloadMembers(key *jwa.JWK) (map[string]json.RawMessage, error) {
+	members := map[string]json.RawMessage{}
+
+	if len(key.Payload) == 0 {
+		return members, nil
+	}
+
+	err := json.Unmarshal(key.Payload, &members)
+	if err != nil {
+		return nil, fmt.Errorf("(jwk) decode key payload: %w", err)
+	}
+
+	return members, nil
+}

--- a/jwk/public_test.go
+++ b/jwk/public_test.go
@@ -1,0 +1,139 @@
+package jwk_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/a-novel-kit/jwt/v2/jwa"
+	"github.com/a-novel-kit/jwt/v2/jwk"
+)
+
+// Covers every key type the package generates, since the private members differ
+// by type and a type reading as public when it is not is the whole risk.
+
+func members(t *testing.T, key *jwa.JWK) map[string]json.RawMessage {
+	t.Helper()
+
+	out := map[string]json.RawMessage{}
+	if len(key.Payload) > 0 {
+		require.NoError(t, json.Unmarshal(key.Payload, &out))
+	}
+
+	return out
+}
+
+func TestHasPrivateMaterial(t *testing.T) {
+	t.Parallel()
+
+	rsaPrivate, rsaPublic, err := jwk.GenerateRSA(jwk.RS256)
+	require.NoError(t, err)
+
+	ecPrivate, ecPublic, err := jwk.GenerateECDSA(jwk.ES256)
+	require.NoError(t, err)
+
+	edPrivate, edPublic, err := jwk.GenerateED25519()
+	require.NoError(t, err)
+
+	ecdhPrivate, ecdhPublic, err := jwk.GenerateECDH()
+	require.NoError(t, err)
+
+	hmacKey, err := jwk.GenerateHMAC(jwk.HS256)
+	require.NoError(t, err)
+
+	aesKey, err := jwk.GenerateAES(jwk.A256GCM)
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name string
+
+		key *jwa.JWK
+
+		expect bool
+	}{
+		{name: "RSA/Private", key: rsaPrivate.JWK, expect: true},
+		{name: "RSA/Public", key: rsaPublic.JWK, expect: false},
+		{name: "ECDSA/Private", key: ecPrivate.JWK, expect: true},
+		{name: "ECDSA/Public", key: ecPublic.JWK, expect: false},
+		{name: "ED25519/Private", key: edPrivate.JWK, expect: true},
+		{name: "ED25519/Public", key: edPublic.JWK, expect: false},
+		{name: "ECDH/Private", key: ecdhPrivate.JWK, expect: true},
+		{name: "ECDH/Public", key: ecdhPublic.JWK, expect: false},
+		// A symmetric key is its secret whatever its payload says.
+		{name: "HMAC", key: hmacKey.JWK, expect: true},
+		{name: "AES", key: aesKey.JWK, expect: true},
+		{name: "Nil", key: nil, expect: false},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := jwk.HasPrivateMaterial(testCase.key)
+			require.NoError(t, err)
+			require.Equal(t, testCase.expect, got)
+		})
+	}
+}
+
+func TestPublicStripsPrivateMembers(t *testing.T) {
+	t.Parallel()
+
+	rsaPrivate, _, err := jwk.GenerateRSA(jwk.RS256)
+	require.NoError(t, err)
+
+	// RSA carries the widest private set, so it is the one that proves every
+	// name is removed rather than just "d".
+	private := members(t, rsaPrivate.JWK)
+	for _, name := range []string{"d", "p", "q", "dp", "dq", "qi"} {
+		require.Contains(t, private, name, "the generated key should carry %s to begin with", name)
+	}
+
+	public, err := jwk.Public(rsaPrivate.JWK)
+	require.NoError(t, err)
+
+	got := members(t, public)
+	for _, name := range []string{"d", "p", "q", "dp", "dq", "qi", "oth"} {
+		require.NotContains(t, got, name)
+	}
+
+	// The public half has to remain usable.
+	require.Contains(t, got, "n")
+	require.Contains(t, got, "e")
+
+	require.Equal(t, rsaPrivate.KID, public.KID)
+	require.Equal(t, rsaPrivate.KTY, public.KTY)
+
+	hasPrivate, err := jwk.HasPrivateMaterial(public)
+	require.NoError(t, err)
+	require.False(t, hasPrivate)
+
+	// The input is left alone, so a caller projecting a key it still signs with
+	// does not disarm its own signer.
+	require.Contains(t, members(t, rsaPrivate.JWK), "d")
+}
+
+func TestPublicRefusesASymmetricKey(t *testing.T) {
+	t.Parallel()
+
+	// There is no public half to return. Emptying the payload would produce a
+	// key that looks publishable and verifies nothing.
+	hmacKey, err := jwk.GenerateHMAC(jwk.HS256)
+	require.NoError(t, err)
+
+	_, err = jwk.Public(hmacKey.JWK)
+	require.ErrorIs(t, err, jwk.ErrPrivateKeyMaterial)
+}
+
+func TestPublicOnAnAlreadyPublicKey(t *testing.T) {
+	t.Parallel()
+
+	// Idempotent, so a caller need not track whether it has already projected.
+	_, ecPublic, err := jwk.GenerateECDSA(jwk.ES256)
+	require.NoError(t, err)
+
+	public, err := jwk.Public(ecPublic.JWK)
+	require.NoError(t, err)
+	require.JSONEq(t, string(ecPublic.Payload), string(public.Payload))
+}

--- a/jwp/key_embedder.go
+++ b/jwp/key_embedder.go
@@ -20,8 +20,13 @@ type EmbedKeyConfig struct {
 	KID string
 	// JWK Set URL recorded in the header's "jku" field, telling recipients where to fetch the key.
 	URL string
-	// Embed writes the full key into the header. When false, only the identifier is written, to
+	// Embed writes the key itself into the header. When false, only the identifier is written, to
 	// keep the token small.
+	//
+	// The key must be a public one. A header travels inside the token, so embedding a key that
+	// carries private material hands the signing key to every recipient; Header refuses it with
+	// [jwk.ErrPrivateKeyMaterial]. Source resolves the signing key, private half included, so pass
+	// [jwk.Public] over it — a symmetric key cannot be embedded at all.
 	Embed bool
 }
 
@@ -60,6 +65,19 @@ func (plugin *EmbedKey) Header(ctx context.Context, header *jwa.JWH) (*jwa.JWH, 
 	header.JKU = plugin.config.URL
 
 	if plugin.config.Embed && key != nil {
+		// The header ships inside the token, so a key with private material here
+		// hands the signing key to every recipient of every token. Source
+		// resolves signing keys, which is exactly where that key comes from.
+		private, err := jwk.HasPrivateMaterial(key)
+		if err != nil {
+			return nil, fmt.Errorf("(EmbedKey.Header) inspect key: %w", err)
+		}
+
+		if private {
+			return nil, fmt.Errorf("(EmbedKey.Header) refusing to embed %s key %q: %w",
+				key.KTY, kid, jwk.ErrPrivateKeyMaterial)
+		}
+
 		header.JWK = key
 	}
 

--- a/jwp/key_embedder_test.go
+++ b/jwp/key_embedder_test.go
@@ -25,12 +25,23 @@ func TestKeyEmbedder(t *testing.T) {
 
 	keySource := testutils.NewStaticKeysSource(t, []*jwk.Key[[]byte]{otherKey, olderKey})
 
+	// An asymmetric pair, to separate "carries private material" from "is
+	// symmetric": the private half must be refused and the public half embedded.
+	signingKey, _, err := jwk.GenerateED25519()
+	require.NoError(t, err)
+
+	publicKey, err := jwk.Public(signingKey.JWK)
+	require.NoError(t, err)
+
 	testCases := []struct {
 		name string
 
 		config jwp.EmbedKeyConfig
 
 		expect *jwa.JWH
+		// expectErr is set on the configurations that must not produce a header
+		// at all.
+		expectErr error
 	}{
 		{
 			name: "Minimalistic",
@@ -84,24 +95,40 @@ func TestKeyEmbedder(t *testing.T) {
 			},
 		},
 		{
-			name: "KeyDirectEmbed",
+			// A symmetric key is its own secret, so embedding one publishes the
+			// signing key in every token it signs.
+			name: "KeyDirectEmbed/Symmetric",
 
 			config: jwp.EmbedKeyConfig{Key: key.JWK, Embed: true},
 
-			expect: &jwa.JWH{
-				JWHCommon: jwa.JWHCommon{
-					JWHEmbeddedKey: jwa.JWHEmbeddedKey{KID: key.KID, JWK: key.JWK},
-				},
-			},
+			expectErr: jwk.ErrPrivateKeyMaterial,
 		},
 		{
-			name: "KeySourcedEmbed",
+			// Source resolves signing keys, which is where a private key comes
+			// from. This is the configuration that would leak on every token.
+			name: "KeySourcedEmbed/Symmetric",
 
 			config: jwp.EmbedKeyConfig{Source: keySource, Embed: true},
 
+			expectErr: jwk.ErrPrivateKeyMaterial,
+		},
+		{
+			name: "KeyDirectEmbed/AsymmetricPrivate",
+
+			config: jwp.EmbedKeyConfig{Key: signingKey.JWK, Embed: true},
+
+			expectErr: jwk.ErrPrivateKeyMaterial,
+		},
+		{
+			// The public half is what the affordance exists for: a recipient can
+			// verify with it, and it gives nothing away.
+			name: "KeyDirectEmbed/AsymmetricPublic",
+
+			config: jwp.EmbedKeyConfig{Key: publicKey, Embed: true},
+
 			expect: &jwa.JWH{
 				JWHCommon: jwa.JWHCommon{
-					JWHEmbeddedKey: jwa.JWHEmbeddedKey{KID: otherKey.KID, JWK: otherKey.JWK},
+					JWHEmbeddedKey: jwa.JWHEmbeddedKey{KID: publicKey.KID, JWK: publicKey},
 				},
 			},
 		},
@@ -112,7 +139,16 @@ func TestKeyEmbedder(t *testing.T) {
 			t.Parallel()
 
 			embedder := jwp.NewEmbedKey(testCase.config)
+
 			header, err := embedder.Header(t.Context(), &jwa.JWH{})
+
+			if testCase.expectErr != nil {
+				require.ErrorIs(t, err, testCase.expectErr)
+				require.Nil(t, header)
+
+				return
+			}
+
 			require.NoError(t, err)
 			require.Equal(t, testCase.expect, header)
 		})


### PR DESCRIPTION
Item 4 of #480, per your ruling to fix everything. The most severe thing left in the milestone.

## The defect

```go
if plugin.config.Embed && key != nil {
    header.JWK = key
}
```

`EmbedKey` is documented as recording the signing key *"so recipients can locate it"* — a **verification** affordance, which needs the **public** half. But `EmbedKeyConfig.Source` is *"keys resolved at signing time"*, and the sourced signers (`jws/rsa.go:254`, `jws/ecdsa.go:214`, `jws/hmac.go:171`) deliberately resolve **private** keys from exactly that kind of source. Nothing projected the key down.

So a producer wired as `EmbedKey{Source: signingKeySource, Embed: true}` emits **every token** with the full private JWK — `d`, `p`, `q`, `dp`, `dq`, `qi` — inside a bearer credential. Every recipient of any token recovers the signing key and can forge arbitrarily. With a symmetric key the JWK *is* the secret outright.

Not attacker-triggerable, and `NewEmbedKey` has no caller in any service, so there is no live exposure. It is a one-line misconfiguration with no guard, no warning, and no way to notice: the tokens verify perfectly.

## The fix

`Header` inspects the resolved key and returns `jwk.ErrPrivateKeyMaterial` instead of embedding it.

Erroring alone would leave the affordance unusable, so **`jwk.Public`** projects a key to its public half. It refuses a symmetric key rather than emptying its payload — that would produce a key that *looks* publishable and verifies nothing, which is the same class of silent failure this milestone is about.

The private member set is fixed by RFC 7518 §6, listed once, and read by both the check and the projection:

```go
"d", "p", "q", "dp", "dq", "qi", "oth",  // RSA private exponent and CRT factors; EC/OKP scalar
"k",                                      // symmetric key value
```

I chose **hard error over silent projection**. Auto-projecting would be friendlier, but this milestone exists because silence is the problem, and a caller who wrote `Embed: true` over a signing source has a mistaken model of what that field does — the doc now says so, and the error says so at the point of use.

## The tests asserted the leak

`KeyDirectEmbed` and `KeySourcedEmbed`, both built on `jwk.GenerateHMAC(jwk.HS256)` — a JWK containing a raw secret — both `require.Equal`ing that the full JWK lands in `header.JWK`. They are now the negative cases.

Added an asymmetric pair so "carries private material" is separated from "is symmetric": the Ed25519 **private** half is refused, and its **public** half embeds normally. That is the case proving the affordance still works.

Red check:

```
--- FAIL: TestKeyEmbedder/KeySourcedEmbed/Symmetric
--- FAIL: TestKeyEmbedder/KeyDirectEmbed/Symmetric
--- FAIL: TestKeyEmbedder/KeyDirectEmbed/AsymmetricPrivate
```

`jwk/public_test.go` covers the new API across **every** key type the package generates — RSA, ECDSA, Ed25519, ECDH, HMAC, AES — since the private members differ by type and a type reading as public when it is not is the entire risk. It also pins that `Public` leaves its input alone (a caller projecting a key it still signs with must not disarm its own signer) and that it is idempotent.

Full suite: 11 packages ok, `golangci-lint` 0 issues.

## Release

New exported API (`jwk.Public`, `jwk.HasPrivateMaterial`, `jwk.ErrPrivateKeyMaterial`) plus a behaviour change that turns a working call into an error — **minor**, same precedent as v2.2.0. I'd batch it with the rest of #480 rather than tag per item; happy to write the migration note once the set is known.

## Remaining in #480

Items 1–3 are RFC conformance and I'll take them next: PBES2 salt derivation and ECDH-ES `apu`/`apv` (both breaking wire changes, so one PR and one migration note), then the ECDSA curve binding. Plus two issues to file from the "also worth a look" section — the `crypto/sha256` registration gap is a real packaging bug that panics a minimal consumer.
