### PR TITLE
fix(jws,jwe): link in the hash implementations the presets name

### DIFF
--- a/.github/scripts/lint-hash-registration.sh
+++ b/.github/scripts/lint-hash-registration.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Every package that names a crypto.Hash must link the implementation in.
+#
+# crypto.Hash is a registry of identifiers, not implementations. crypto.SHA256 is a number, and
+# New() on it panics with "requested hash function #5 is unavailable" unless some package has
+# registered SHA-256 from its init. The standard library's hash packages do that for themselves, so
+# a package naming a hash without importing one leaves the job to its consumer.
+#
+# That failure cannot be caught by the test suite. A test binary pulls in the hash packages through
+# its own dependencies — testify, crypto/ecdsa — so every hash reads as available no matter what the
+# library imports. Only a consumer importing the library alone finds out, at run time, in
+# production, having built cleanly.
+#
+# So the rule is checked structurally: name a hash, import its registrar.
+set -euo pipefail
+
+ROOT="${1:-.}"
+
+# hash identifier -> the standard library package whose init registers it
+declare -A REGISTRAR=(
+  [SHA1]=crypto/sha1
+  [SHA224]=crypto/sha256
+  [SHA256]=crypto/sha256
+  [SHA384]=crypto/sha512
+  [SHA512]=crypto/sha512
+)
+
+fail=0
+
+# Package directories holding non-test Go sources that name a hash.
+while IFS= read -r dir; do
+  used=$(grep -rhoE 'crypto\.SHA[0-9]+' "$dir"/*.go 2>/dev/null |
+    grep -v '_test.go' | sed 's/crypto\.//' | sort -u || true)
+  [ -n "$used" ] || continue
+
+  for hash in $used; do
+    registrar="${REGISTRAR[$hash]:-}"
+    if [ -z "$registrar" ]; then
+      echo "::error file=${dir}::crypto.${hash} has no known registrar in this check — add one to REGISTRAR."
+      fail=1
+
+      continue
+    fi
+
+    # The blank import may live in any non-test file of the package.
+    if ! grep -rqE "^[[:space:]]*_ \"${registrar}\"" "$dir"/*.go 2>/dev/null; then
+      echo "::error file=${dir}::package names crypto.${hash} but no file imports \`_ \"${registrar}\"\`, so calling New() on it panics for a consumer that imports this package alone. Add the blank import (see hashes.go)."
+      fail=1
+    fi
+  done
+done < <(find "$ROOT" -type f -name '*.go' -not -name '*_test.go' -not -path '*/node_modules/*' \
+  -exec dirname {} \; | sort -u)
+
+if [ "$fail" -ne 0 ]; then
+  exit 1
+fi
+
+echo "✓ every package naming a crypto.Hash imports its registrar."

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,6 +17,20 @@ jobs:
         with:
           modfile: gotestsum.mod
 
+  # A package that names a crypto.Hash without importing its registrar builds cleanly, passes every
+  # test — a test binary links the hash packages through its own dependencies — and panics in a
+  # consumer that imports the library alone. The check is structural because nothing inside the test
+  # suite can observe the gap.
+  lint-hash-registration:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+      - name: Every package naming a crypto.Hash imports its registrar
+        shell: bash
+        run: bash .github/scripts/lint-hash-registration.sh .
+
   lint-go:
     runs-on: ubuntu-latest
     permissions:

--- a/jwe/hashes.go
+++ b/jwe/hashes.go
@@ -1,0 +1,16 @@
+package jwe
+
+// Link in the hash implementations this package's presets name.
+//
+// crypto.Hash is a registry of identifiers, not implementations: crypto.SHA256 is a number, and
+// calling New on it panics with "requested hash function #5 is unavailable" unless something has
+// linked the implementation in. The standard library's hash packages register themselves from init,
+// so naming a hash without importing one leaves that to whoever imports this package — and a
+// consumer that imports only jwt and this package panics on its first operation, at run time,
+// having built cleanly.
+//
+// crypto/sha512 registers SHA-384 and SHA-512 both.
+import (
+	_ "crypto/sha256"
+	_ "crypto/sha512"
+)

--- a/jwe/internal/hashes.go
+++ b/jwe/internal/hashes.go
@@ -1,0 +1,14 @@
+package internal
+
+// Link in the hash implementations this package's presets name.
+//
+// crypto.Hash is a registry of identifiers, not implementations: crypto.SHA256 is a number, and
+// calling New on it panics with "requested hash function #5 is unavailable" unless something has
+// linked the implementation in. The standard library's hash packages register themselves from init,
+// so naming a hash without importing one leaves that to whoever imports this package — and a
+// consumer that imports only jwt and this package panics on its first operation, at run time,
+// having built cleanly.
+
+import (
+	_ "crypto/sha256"
+)

--- a/jwe/jwek/hashes.go
+++ b/jwe/jwek/hashes.go
@@ -1,0 +1,16 @@
+package jwek
+
+// Link in the hash implementations this package's presets name.
+//
+// crypto.Hash is a registry of identifiers, not implementations: crypto.SHA256 is a number, and
+// calling New on it panics with "requested hash function #5 is unavailable" unless something has
+// linked the implementation in. The standard library's hash packages register themselves from init,
+// so naming a hash without importing one leaves that to whoever imports this package — and a
+// consumer that imports only jwt and this package panics on its first operation, at run time,
+// having built cleanly.
+//
+// crypto/sha512 registers SHA-384 and SHA-512 both.
+import (
+	_ "crypto/sha256"
+	_ "crypto/sha512"
+)

--- a/jws/hashes.go
+++ b/jws/hashes.go
@@ -1,0 +1,16 @@
+package jws
+
+// Link in the hash implementations this package's presets name.
+//
+// crypto.Hash is a registry of identifiers, not implementations: crypto.SHA256 is a number, and
+// calling New on it panics with "requested hash function #5 is unavailable" unless something has
+// linked the implementation in. The standard library's hash packages register themselves from init,
+// so naming a hash without importing one leaves that to whoever imports this package — and a
+// consumer that imports only jwt and this package panics on its first operation, at run time,
+// having built cleanly.
+//
+// crypto/sha512 registers SHA-384 and SHA-512 both.
+import (
+	_ "crypto/sha256"
+	_ "crypto/sha512"
+)


### PR DESCRIPTION
The packaging bug from #480's "also worth a look". I verified it before filing and it is worse than the note suggested, so I fixed it rather than opening an issue: **the published library is unusable by a minimal consumer.**

## Reproduced against released v2.2.1

A module importing `jwt`, `jwk` and `jws`, signing one token:

```
panic: crypto: requested hash function #5 is unavailable

crypto.Hash.New(...)
github.com/a-novel-kit/jwt/v2/jws.(*ECDSASigner).Transform(...)
github.com/a-novel-kit/jwt/v2.(*Producer).Issue(...)
```

Hash #5 is SHA-256. `crypto.Hash` is a registry of **identifiers, not implementations** — `crypto.SHA256` is a number, and `New()` on it panics unless some package has registered SHA-256 from its `init`. The standard library's hash packages do that for themselves, and none of `jws`, `jwe`, `jwe/jwek` or `jwe/internal` imported one, so the job fell to the consumer.

Builds cleanly. Panics at run time. On the first signature.

Same module against this branch:

```
token: eyJhbGciOiJFUzI1NiJ9.eyJzdWIiOiJ4In0.FYy93uemzu-...  err: <nil>
```

## Why there is no unit test here

This is the part worth reviewing. **The suite structurally cannot catch it.**

A test binary links the hash packages through its *own* dependencies — testify, `crypto/ecdsa` — so `crypto.SHA256.Available()` is `true` in every test regardless of what the library imports. I checked rather than assumed: with `jws/hashes.go` removed, a probe test still reported

```
SHA256=true SHA384=true SHA512=true
```

So an `Available()` assertion would pass **before and after** the fix. That is precisely the vacuous-green shape this milestone exists to eliminate, and adding one would have been worse than adding nothing — it would look like coverage.

## The gate instead

`.github/scripts/lint-hash-registration.sh` checks the rule structurally: every package naming a `crypto.SHA*` must carry the blank import that registers it. Deterministic, no toolchain gymnastics, and it states the invariant that was broken.

Red check — removing any one `hashes.go`:

```
::error file=./jws::package names crypto.SHA256 but no file imports `_ "crypto/sha256"`, so
  calling New() on it panics for a consumer that imports this package alone.
::error file=./jws::package names crypto.SHA384 but no file imports `_ "crypto/sha512"` …
::error file=./jws::package names crypto.SHA512 but no file imports `_ "crypto/sha512"` …
```

Wired as a `lint-hash-registration` job in `main.yaml`. It will bite again the moment a new preset lands in a new package, which is the only way this recurs.

## The fix

A `hashes.go` per affected package — `jws`, `jwe`, `jwe/jwek`, `jwe/internal` — carrying the blank imports and the explanation. A dedicated file rather than a line buried in `common.go`, because the next person to hit this needs to find it. `crypto/sha512` registers SHA-384 and SHA-512 both; `jwe/internal` names only SHA-256 and imports only that.

11 packages ok, `golangci-lint` 0 issues, prettier clean.

## Release

**Patch-worthy on its own** — this is a straight bug fix with no behaviour change for anyone whose consumer already happened to link a hash. It rides along in v2.3.0 with the rest of #480.

## One item left from #480's tail

RFC 7519 §5.3 replicated header claims are never cross-checked against the payload, though `jwa/jwh.go:80-90` documents that they must match. No consumer makes a trust decision from the header copy today, so it is likely documentation drift rather than a defect — I'll file it as a question rather than guess which side is wrong.
