### PR TITLE
chore(ci): drop the go-report-card job and README badge

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -46,13 +46,3 @@ jobs:
           codecov_token: ${{ secrets.CODECOV_TOKEN }}
           coverage_files: coverage.txt
           coverage_artifact_ids: ${{ needs.test.outputs.artifact-id }}
-
-  report-grc:
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master' && success()
-    needs: [test-go, lint-go]
-    permissions:
-      contents: read
-    steps:
-      - uses: a-novel-kit/workflows/go-actions/go-report-card@v1.23.0
-        if: github.ref == 'refs/heads/master' && success()

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ A modular JWT, JWS, JWE, and JWK library for Go.
 ![GitHub repo file or directory count](https://img.shields.io/github/directory-file-count/a-novel-kit/jwt)
 ![GitHub code size in bytes](https://img.shields.io/github/languages/code-size/a-novel-kit/jwt)
 ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/a-novel-kit/jwt/main.yaml)
-[![Go Report Card](https://goreportcard.com/badge/github.com/a-novel-kit/jwt/v2)](https://goreportcard.com/report/github.com/a-novel-kit/jwt/v2)
 [![codecov](https://codecov.io/gh/a-novel-kit/jwt/graph/badge.svg)](https://codecov.io/gh/a-novel-kit/jwt)
 
 ![Coverage graph](https://codecov.io/gh/a-novel-kit/jwt/graphs/sunburst.svg)


### PR DESCRIPTION
## Summary

- Removes the post-merge `report-grc` job and the Go Report Card README badge.
- [Go Report Card was sunset](https://goreportcard.com/report/github.com/a-novel/service-authentication) in July 2026 — the job POSTed to a now-dead endpoint and the badge renders broken. `golangci-lint` (the `lint-go` check) remains the real static-analysis gate.

## Breaking changes

None.

## Test plan

- [ ] CI green