### PR TITLE
fix(ci): repair report-codecov's coverage artifact reference

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -114,8 +114,6 @@ jobs:
 
   report-codecov:
     runs-on: ubuntu-latest
-    # test-go alone: it is the job that produces the artifact named below. lint-go was in this
-    # list without contributing anything to the upload.
     needs: [test-go]
     permissions:
       contents: read
@@ -124,8 +122,4 @@ jobs:
         with:
           codecov_token: ${{ secrets.CODECOV_TOKEN }}
           coverage_files: coverage.txt
-          # `needs.test` named no job in this workflow, so this resolved to the empty string and
-          # download-artifact fell through to its download-everything branch, which nests each
-          # artifact under its own directory. codecov then missed coverage.txt at the root and
-          # only found it by globbing. The upload worked by accident; this makes it deliberate.
           coverage_artifact_ids: ${{ needs.test-go.outputs.artifact-id }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,8 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    outputs:
+      artifact-id: ${{ steps.test.outputs.artifact-id }}
     steps:
       - uses: a-novel-kit/workflows/go-actions/test-go@v1.26.1
+        id: test
         with:
           modfile: gotestsum.mod
 
@@ -111,7 +114,9 @@ jobs:
 
   report-codecov:
     runs-on: ubuntu-latest
-    needs: [test-go, lint-go]
+    # test-go alone: it is the job that produces the artifact named below. lint-go was in this
+    # list without contributing anything to the upload.
+    needs: [test-go]
     permissions:
       contents: read
     steps:
@@ -119,4 +124,8 @@ jobs:
         with:
           codecov_token: ${{ secrets.CODECOV_TOKEN }}
           coverage_files: coverage.txt
-          coverage_artifact_ids: ${{ needs.test.outputs.artifact-id }}
+          # `needs.test` named no job in this workflow, so this resolved to the empty string and
+          # download-artifact fell through to its download-everything branch, which nests each
+          # artifact under its own directory. codecov then missed coverage.txt at the root and
+          # only found it by globbing. The upload worked by accident; this makes it deliberate.
+          coverage_artifact_ids: ${{ needs.test-go.outputs.artifact-id }}


### PR DESCRIPTION
## Summary

`report-codecov` passed `coverage_artifact_ids: ${{ needs.test.outputs.artifact-id }}`. **No job in
this workflow is called `test`** — the job is `test-go` — so the expression resolved to the empty
string, silently. It also would not have worked spelled correctly: `test-go` declared no `outputs`
block and its step had no `id`, so there was nothing to read.

The upload has been working by accident. With an empty `artifact-ids` *and* an empty `name`,
`actions/download-artifact@v8` takes its download-everything branch, which nests each artifact under
a directory of its own. `codecov-action` was then told `files: coverage.txt`, missed it at the root,
logged `Some files were not found --- {"not_found_files": ["coverage.txt"]}`, and only found it by
globbing — from the last green `master` run:

```
warning -- Some files were not found --- {"not_found_files": ["coverage.txt"]}
info    -- Found 1 coverage files to report
info    -- > /home/runner/work/jwt/jwt/coverage/coverage.txt
```

That is one artifact name away from silently uploading nothing, with `fail_ci_if_error: true` unable
to notice.

## Changes

- `test-go` declares `outputs.artifact-id` and gives its step `id: test`, matching how every
  `a-novel/service-*` repo wires the same action.
- `report-codecov` reads `needs.test-go.outputs.artifact-id`, so `download-artifact` fetches that one
  artifact by ID and extracts `coverage.txt` at the workspace root, where `files:` expects it.
- `report-codecov` drops `lint-go` from its `needs`. It contributed nothing to the upload and only
  delayed it.

## Required checks

No job was added, renamed or removed — the derived required-check list is unchanged, so no
`a-novel repo update` is needed.

## Test plan

- [x] file parses; no cycles; every `needs.X` expression now names a job that is in that job's `needs`
- [x] `prettier --check` clean
- [x] `zizmor` 1.28.0 clean
- [ ] CI green, and the `report-codecov` log no longer prints `not_found_files`

🤖 Generated with [Claude Code](https://claude.com/claude-code)